### PR TITLE
feat: show job work mode, salary, and work load on mobile job listing

### DIFF
--- a/components/features/student/header.tsx
+++ b/components/features/student/header.tsx
@@ -167,7 +167,7 @@ const WORKLOAD_OPTIONS: SubOption[] = [
 ];
 
 const MODE_OPTIONS: SubOption[] = [
-  { name: "Face-to-face", value: "0" },
+  { name: "Onsite", value: "0" },
   { name: "Hybrid", value: "1" },
   { name: "Remote", value: "2" },
 ];

--- a/components/modals/JobModal.tsx
+++ b/components/modals/JobModal.tsx
@@ -1,5 +1,5 @@
 import ReactMarkdown from "react-markdown";
-import { JobApplicationRequirements, JobBadges } from "../shared/jobs";
+import { JobApplicationRequirements, JobBadges, JobDetailsSummary } from "../shared/jobs";
 import { useApplications, useSavedJobs } from "@/lib/api/student.api";
 import { ModalComponent, ModalHandle } from "@/hooks/use-modal";
 import { ArrowLeft, Building, Heart } from "lucide-react";
@@ -68,6 +68,7 @@ export const JobModal = ({
               </div>
 
               {/* Description */}
+              <JobDetailsSummary job={job}></JobDetailsSummary>
               <div className="mb-6">
                 <h2 className="text-lg font-semibold mb-3 text-gray-900">
                   Description

--- a/components/shared/jobs.tsx
+++ b/components/shared/jobs.tsx
@@ -738,6 +738,53 @@ export const EmployerJobDetails = ({
   );
 };
 
+export const JobDetailsSummary = ({
+  job
+}: {
+  job: Job;
+}) => {
+  const { to_job_mode_name, to_job_type_name, to_job_pay_freq_name } =
+    useDbRefs();
+
+  return <div className="mb-6">
+          <h3 className="text-lg font-semibold mb-4">Job Details</h3>
+          <div className="grid grid-cols-3 gap-6">
+            <DropdownGroup>
+              <div className="flex flex-col items-start gap-3">
+                <label className="flex items-center text-sm font-semibold text-gray-700">
+                  <Monitor className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
+                  Work Mode:
+                </label>
+                <Property value={to_job_mode_name(job.mode)} />
+              </div>
+
+              <div className="flex flex-col items-start gap-3 max-w-prose">
+                <label className="flex items-center text-sm font-semibold text-gray-700">
+                  <PhilippinePeso className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
+                  Salary:
+                </label>
+                <Property
+                  value={
+                    job.salary
+                      ? `${job.salary}/${to_job_pay_freq_name(job.salary_freq)}`
+                      : "None"
+                  }
+                />
+              </div>
+              <div className="flex flex-col items-start gap-3 max-w-prose">
+                <label className="flex items-center text-sm font-semibold text-gray-700">
+                  <Clock className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
+                  Work Load:
+                </label>
+                <Property value={to_job_type_name(job.type)} />
+              </div>
+            </DropdownGroup>
+
+            {/* // ! checkbox labels */}
+          </div>
+        </div>
+}
+
 /**
  * The right panel that describes job details.
  *
@@ -750,9 +797,6 @@ export const JobDetails = ({
   job: Job;
   actions?: React.ReactNode[];
 }) => {
-  const { to_job_mode_name, to_job_type_name, to_job_pay_freq_name } =
-    useDbRefs();
-
   // Returns a non-editable version of it
   return (
     <div className="flex-1 border-gray-200 rounded-lg ml-4 p-6 pt-10 overflow-y-auto">
@@ -773,43 +817,7 @@ export const JobDetails = ({
       </div>
 
       {/* Job Details Grid */}
-      <div className="mb-6">
-        <h3 className="text-lg font-semibold mb-4">Job Details</h3>
-        <div className="grid grid-cols-3 gap-6">
-          <DropdownGroup>
-            <div className="flex flex-col items-start gap-3">
-              <label className="flex items-center text-sm font-semibold text-gray-700">
-                <Monitor className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
-                Work Mode:
-              </label>
-              <Property value={to_job_mode_name(job.mode)} />
-            </div>
-
-            <div className="flex flex-col items-start gap-3 max-w-prose">
-              <label className="flex items-center text-sm font-semibold text-gray-700">
-                <PhilippinePeso className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
-                Salary:
-              </label>
-              <Property
-                value={
-                  job.salary
-                    ? `${job.salary}/${to_job_pay_freq_name(job.salary_freq)}`
-                    : "None"
-                }
-              />
-            </div>
-            <div className="flex flex-col items-start gap-3 max-w-prose">
-              <label className="flex items-center text-sm font-semibold text-gray-700">
-                <Clock className="h-5 w-5 text-gray-400 mt-0.5 mr-2" />
-                Work Load:
-              </label>
-              <Property value={to_job_type_name(job.type)} />
-            </div>
-          </DropdownGroup>
-
-          {/* // ! checkbox labels */}
-        </div>
-      </div>
+      <JobDetailsSummary job={job}></JobDetailsSummary>
 
       {/* Job Description */}
       <hr />

--- a/components/ui/labels.tsx
+++ b/components/ui/labels.tsx
@@ -72,7 +72,7 @@ export const Property: ValueComponent = ({
   className = "",
 }: ValueComponentProps) => {
   return (
-    <p
+    <div
       className={cn(
         "text-gray-700 text-sm overflow-hidden text-ellipsis",
         className
@@ -83,7 +83,7 @@ export const Property: ValueComponent = ({
           {fallback ?? DEFAULT_LABEL}
         </span>
       )}
-    </p>
+    </div>
   );
 };
 


### PR DESCRIPTION
Currently, the mobile view does not show the work mode, salary, and workload like on the desktop view.

Please look at these images for reference:

Current desktop view (note the "job details" section):
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/21db7d3c-6806-483e-b691-92c3bb0b0a9b" />

Current mobile view (note that the "job details" section is missing):
<img width="711" height="1003" alt="image" src="https://github.com/user-attachments/assets/59aaf18b-e23a-4b38-8ebe-f8df08bcc043" />

Proposed mobile view:
<img width="717" height="1007" alt="image" src="https://github.com/user-attachments/assets/3bcce2b4-0e8c-4a1a-a4dc-59d8dfb98d26" />
