### PR TITLE
fix: forgot password text wrap issue on mobile

### DIFF
--- a/app/hire/forgot-password/page.tsx
+++ b/app/hire/forgot-password/page.tsx
@@ -1,22 +1,28 @@
 "use client";
 
 import { useState } from "react";
-import { useAuthContext } from "../authctx";
 
 import { Card } from "@/components/ui/card";
 import { FormInput } from "@/components/EditForm";
 import { Button } from "@/components/ui/button";
-import { isValidEmail } from "@/lib/utils";
-import { normalize } from "path";
-import { AuthService, EmployerUserService } from "@/lib/api/services";
+import { EmployerUserService } from "@/lib/api/services";
+import { cn } from "@/lib/utils";
+import { useAppContext } from "@/lib/ctx-app";
 
 /**
  * Display the layout for the forgot password page.
  */
 export default function ForgotPasswordPage() {
+  const { isMobile } = useAppContext();
+
   return (
-    <div className="flex justify-center px-6 py-12 h-full">
-      <div className="flex justify-center items-center w-full max-w-2xl h-full">
+    <div className={cn(
+      "flex justify-center py-12 pt-12 h-full overflow-y-auto",
+      isMobile
+        ? "px-2"
+        : "px-6"
+    )}>
+      <div className="flex justify-center w-full max-w-2xl h-fit">
         <ForgotPasswordForm />
       </div>
     </div>
@@ -34,6 +40,7 @@ const ForgotPasswordForm = ({}) => {
 
   // send password reset request if a valid email is entered.
   const handle_request = async (e: React.FormEvent) => {
+    e.preventDefault();
     setIsLoading(true);
     setError("");
     setMessage("");
@@ -71,11 +78,12 @@ const ForgotPasswordForm = ({}) => {
           onChange={(e) => setEmail(e.target.value)}
           value={email}
         />
-        <div className="flex justify-between items-center w-[100%]">
-          <span className="text-sm text-gray-500">
-            Already know your password? <a className="text-blue-600 hover:text-blue-800 underline font-medium" href="/login">Log in here.</a>
-          </span>
+        <span className="text-sm text-gray-500">
+          Remember your password? <a className="text-blue-600 hover:text-blue-800 underline font-medium" href="/login">Log in here.</a>
+        </span>
+        <div className="flex justify-end items-center w-[100%]">
           <Button
+            type="submit"
             onClick={handle_request}
             disabled={isLoading}
           >

--- a/app/hire/login/page.tsx
+++ b/app/hire/login/page.tsx
@@ -3,8 +3,9 @@
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useAuthContext } from "../authctx";
+import { cn } from "@/lib/utils";
+import { useAppContext } from "@/lib/ctx-app";
 
 import {
   FormInput,
@@ -23,10 +24,11 @@ export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [emailNorm, setEmailNorm] = useState(""); // keep a normalized copy for API calls
   const [password, setPassword] = useState("");
-  const [new_account, set_new_account] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
+
+  const { isMobile } = useAppContext();
 
   redirect_if_not_logged_in();
   redirect_if_logged_in();
@@ -79,7 +81,12 @@ export default function LoginPage() {
 
   
   return (
-    <div className="flex-1 flex items-center justify-center px-6 py-12 h-full">
+    <div className={cn(
+      "flex justify-center py-12 pt-12 h-fit overflow-y-auto",
+      isMobile
+        ? "px-2"
+        : "px-6"
+    )}>
       <div className="flex items-center w-full max-w-2xl h-full">
         <Card className="w-full">
           {/* Welcome Message */}

--- a/app/hire/register/page.tsx
+++ b/app/hire/register/page.tsx
@@ -17,6 +17,8 @@ import { Button } from "@/components/ui/button";
 import { isValidEmail, isValidPHNumber } from "@/lib/utils";
 import { MultipartFormBuilder } from "@/lib/multipart-form";
 import { Loader } from "@/components/ui/loader";
+import { cn } from "@/lib/utils";
+import { useAppContext } from "@/lib/ctx-app";
 
 const [EmployerRegisterForm, useEmployerRegisterForm] =
   createEditForm<Employer>();
@@ -30,8 +32,15 @@ export default function RegisterPage() {
   if (loading || isAuthenticated())
     return <Loader>Loading registration...</Loader>;
 
+  const { isMobile } = useAppContext();
+
   return (
-    <div className="flex-1 flex justify-center px-6 py-12 pt-12 overflow-y-auto">
+    <div className={cn(
+      "flex-1 flex justify-center py-12 pt-12 overflow-y-auto",
+      isMobile
+        ? "px-2"
+        : "px-6"
+    )}>
       <div className="w-full max-w-2xl h-full">
         <EmployerRegisterForm data={{}}>
           <EmployerEditor registerProfile={register} />

--- a/app/hire/reset-password/[hash]/page.tsx
+++ b/app/hire/reset-password/[hash]/page.tsx
@@ -5,23 +5,29 @@ import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/card";
 import { FormInput } from "@/components/EditForm";
 import { Button } from "@/components/ui/button";
-import { isValidEmail } from "@/lib/utils";
-import { normalize } from "path";
 import { AuthService, EmployerUserService } from "@/lib/api/services";
+import { cn } from "@/lib/utils";
+import { useAppContext } from "@/lib/ctx-app";
 
 /**
  * Display the layout for the change password page.
  */
 
-export default async function ResetPasswordPage({ 
+export default function ResetPasswordPage({ 
   params 
 } : { 
   params: { hash: string }
 }) {
-  const { hash } = await params;
+  const { isMobile } = useAppContext();
+  const { hash } = params;
 
   return (
-    <div className="flex justify-center px-6 py-12 h-full">
+    <div className={cn(
+      "flex justify-center py-12 pt-12 h-full overflow-y-auto",
+      isMobile
+        ? "px-2"
+        : "px-6"
+    )}>
       <div className="flex justify-center items-center w-full max-w-2xl h-full">
         <ResetPasswordForm hash={hash} />
       </div>
@@ -56,7 +62,6 @@ const ResetPasswordForm = ({
 
     try {
       const r = await EmployerUserService.resetPassword(hash, reenterPassword);
-      console.log(r)
       
       // @ts-ignore
       setSuccess(r.message || "Password reset successful. Redirecting to login page in five seconds.");
@@ -90,9 +95,9 @@ const ResetPasswordForm = ({
   return (
     <>
       <Card className="flex flex-col gap-4 w-full">
-      <h2 className="text-3xl tracking-tighter font-bold text-gray-700">
-        Reset your password
-      </h2>
+        <h2 className="text-3xl tracking-tighter font-bold text-gray-700">
+          Reset your password
+        </h2>
         {error && (
           <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
             <p className="text-sm text-red-600 justify-center">{error}</p>
@@ -112,6 +117,7 @@ const ResetPasswordForm = ({
         />
         <div className="flex justify-end items-center w-[100%]">
           <Button
+            type="submit"
             onClick={handle_request}
             disabled={isLoading}
           >


### PR DESCRIPTION
Previously, the label to go back to the log in page from the forgot password page would wrap in an ugly way.