### PR TITLE
feat: prevent accidentally entering applicant view in select mode

### DIFF
--- a/components/features/hire/dashboard/ApplicationRow.tsx
+++ b/components/features/hire/dashboard/ApplicationRow.tsx
@@ -14,30 +14,23 @@ import { EmployerApplication } from "@/lib/db/db.types";
 import { useDbRefs } from "@/lib/db/use-refs";
 import { getFullName } from "@/lib/profile";
 import { cn } from "@/lib/utils";
-import { fmtISO } from "@/lib/utils/date-utils";
+import { formatDateWithoutTime, formatTimestampDateWithoutTime } from "@/lib/utils/date-utils";
 import { statusMap } from "@/components/common/status-icon-map";
 import {
-  Ban,
   Calendar,
-  Check,
-  CheckCircle2,
   ContactRound,
-  FileQuestion,
   GraduationCap,
   MessageCircle,
   School,
-  Star,
   Trash,
-  XCircle,
 } from "lucide-react";
 import { ActionButton } from "@/components/ui/action-button";
 import { FormCheckbox } from "@/components/EditForm";
-import { DropdownGroup } from "@/components/ui/dropdown";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 
 interface ApplicationRowProps {
   application: EmployerApplication;
-  onView: () => void;
+  onView: (v: any) => void;
   onNotes: () => void;
   onSchedule: () => void;
   onStatusChange: (status: number) => void;
@@ -117,19 +110,13 @@ export function ApplicationRow({
           <div className="flex items-center gap-2">
             <ContactRound size={16} />
             <span className="text-sm">
-              {preferences.internship_type ? "For Credit" : "Voluntary"}
+              {preferences.internship_type}
             </span>
           </div>
           <div className="flex items-center gap-2">
             <Calendar size={16} />
             <span className="text-sm">
-              {preferences.expected_start_date ? (
-                <>
-                  {fmtISO(preferences.expected_start_date.toString())}
-                </>
-              ) : (
-                <span className="text-gray-500"> No start date provided</span>
-              )}
+              {formatTimestampDateWithoutTime(preferences.expected_start_date)}
             </span>
           </div>
         </div>
@@ -174,16 +161,14 @@ export function ApplicationRow({
         <span className="text-gray-500">{application.user?.degree}</span>
       </td>
       <td className="px-4 py-2">
-        {preferences.internship_type ? "For Credit" : "Voluntary"}
+        {preferences.internship_type}
       </td>
       <td className="px-4 py-2">
-        {preferences.expected_start_date ? (
-          <>
-            {fmtISO(preferences.expected_start_date.toString())}
-          </>
-        ) : (
-          <span> Not provided</span>
-        )}
+        {formatTimestampDateWithoutTime(preferences.expected_start_date)}
+      </td>
+      <td className="px-4 py-2">
+        {/* man why is the applied at date a string but the expected start date is a number */}
+        {formatDateWithoutTime(application.applied_at)}
       </td>
       <td className="px-4 py-2 overflow-visible">
         <DropdownMenu

--- a/components/features/hire/dashboard/ApplicationsContent.tsx
+++ b/components/features/hire/dashboard/ApplicationsContent.tsx
@@ -258,6 +258,7 @@ export function ApplicationsContent({
         visible={toastVisible}
         title={toastMessage}
         indicator={<CheckCircle2 />}
+        className="top-6 z-[1000]"
       />
       <ApplicationsHeader
         selectedCounts={getCounts(sortedApplications)}
@@ -329,7 +330,13 @@ export function ApplicationsContent({
             <ApplicationRow
               key={application.id}
               application={application}
-              onView={() => onApplicationClick(application)}
+              onView={(v) => {
+                if (selectedApplications.size === 0) {
+                  onApplicationClick(application)
+                } else {
+                  toggleSelect(application.id!, v)
+                }
+              }}
               onNotes={() => onNotesClick(application)}
               onSchedule={() => onScheduleClick(application)}
               onStatusChange={(status) => onStatusChange(application, status)}
@@ -337,7 +344,7 @@ export function ApplicationsContent({
               setSelectedApplication={setSelectedApplication}
               updateConversationId={updateConversationId}
               checkboxSelected={selectedApplications.has(application.id!)}
-              onToggleSelect={(v) => toggleSelect(application.id!, !!v)}
+              onToggleSelect={(v) => toggleSelect(application.id!, v)}
               onStatusButtonClick={updateSingleStatus}
               statuses={getRowStatuses(application.id!)}
             />
@@ -444,7 +451,13 @@ export function ApplicationsContent({
             <th className="p-4">
               <div className="flex items-center gap-2">
                 <Calendar size={16} />
-                <span>Preferred start</span>
+                <span>Expected start date</span>
+              </div>
+            </th>
+            <th className="p-4">
+              <div className="flex items-center gap-2">
+                <Calendar size={16} />
+                <span>Date applied</span>
               </div>
             </th>
             <th className="p-4">
@@ -462,7 +475,13 @@ export function ApplicationsContent({
               <ApplicationRow
                 key={application.id}
                 application={application}
-                onView={() => onApplicationClick(application)}
+                onView={(v) => {
+                  if (selectedApplications.size === 0) {
+                    onApplicationClick(application)
+                  } else {
+                    toggleSelect(application.id!, v)
+                  }
+                }}
                 onNotes={() => onNotesClick(application)}
                 onSchedule={() => onScheduleClick(application)}
                 onStatusChange={(status) => onStatusChange(application, status)}
@@ -470,7 +489,7 @@ export function ApplicationsContent({
                 setSelectedApplication={setSelectedApplication}
                 updateConversationId={updateConversationId}
                 checkboxSelected={selectedApplications.has(application.id!)}
-                onToggleSelect={(v) => toggleSelect(application.id!, !!v)}
+                onToggleSelect={(v) => toggleSelect(application.id!, v)}
                 onStatusButtonClick={updateSingleStatus}
                 statuses={getRowStatuses(application.id!)}
               />

--- a/components/features/hire/dashboard/JobTabs.tsx
+++ b/components/features/hire/dashboard/JobTabs.tsx
@@ -4,7 +4,6 @@ import { useAuthContext } from "@/app/hire/authctx";
 import { ApplicationsContent } from "@/components/features/hire/dashboard/ApplicationsContent";
 import { Card } from "@/components/ui/card";
 import { Loader } from "@/components/ui/loader";
-import { Tab, TabGroup } from "@/components/ui/tabs";
 import { useConversation, useConversations } from "@/hooks/use-conversation";
 import {
   useEmployerApplications,
@@ -51,12 +50,7 @@ export default function JobTabs({
   // Business logic hook
   const {
     saving,
-    isEditing,
-    handleEditStart,
-    handleSave,
-    handleShare,
     clearSelectedJob,
-    setIsEditing,
   } = useListingsBusinessLogic(ownedJobs);
   const { isAuthenticated, redirectIfNotLoggedIn, loading } = useAuthContext();
   const profile = useProfile();
@@ -318,14 +312,16 @@ const handleJobBack = () => {
           <div className={cn(
             "px-4 py-3 bg-white border-gray-200 border-2 rounded-md",
             isMobile
-            ? "flex justify-between gap-2"
+            ? "flex flex-col justify-between gap-4 px-2 py-4"
             : "grid grid-cols-2 grid-rows-2 gap-x-2 gap-y-1 w-fit" 
           )}>
             <div className="flex items-center gap-2">
-              <Toggle
-                state={selectedJob!.is_active}
-                onClick={handleToggleActive}
-              />
+              <div className={isMobile ? "pl-2": ""}>
+                <Toggle
+                  state={selectedJob!.is_active}
+                  onClick={handleToggleActive}
+                />
+              </div>
               <span
                 className={cn(
                   "text-sm transition",
@@ -347,7 +343,7 @@ const handleJobBack = () => {
                   key="edit"
                   variant="ghost"
                   disabled={saving}
-                  className="text-gray-600 hover:bg-primary/10 gap-1"
+                  className="hover:bg-primary/10 gap-1"
                 >
                   <Info size={16} />
                   Preview
@@ -364,7 +360,7 @@ const handleJobBack = () => {
                   key="edit"
                   variant="ghost"
                   disabled={saving}
-                  className="text-gray-600 hover:bg-primary/10 gap-1"
+                  className="hover:bg-primary/10 gap-1"
                 >
                   <Edit size={16} />
                   Edit
@@ -374,7 +370,7 @@ const handleJobBack = () => {
                 key="delete"
                 variant="ghost"
                 disabled={saving}
-                className="text-destructive hover:bg-destructive/10 hover:text-destructive gap-1"
+                className="hover:bg-destructive/10 hover:text-destructive gap-1"
                 onClick={handleJobDelete}
               >
                 <Trash2 />

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/lib/utils";
-import { useState } from "react";
 
 export const Toggle = ({
   state,
@@ -15,7 +14,7 @@ export const Toggle = ({
         onClick();
       }}
       className={cn(
-        "relative inline-flex h-4 w-7 items-center rounded-full transition-colors focus:ring-transparent z-30",
+        "relative flex h-4 w-7 items-center rounded-full transition-colors focus:ring-transparent z-30",
         state ? "bg-primary" : "bg-gray-300"
       )}
     >

--- a/lib/utils/date-utils.ts
+++ b/lib/utils/date-utils.ts
@@ -131,6 +131,39 @@ export const formatDate = (dateString?: string | null) => {
 };
 
 /**
+ * Return a formatted date string from a UNIX timestamp without the time.
+ * @param timestamp Timestamp/date in UNIX timestamp format.
+ * @returns 
+ */
+export const formatTimestampDateWithoutTime = (timestamp?: number | null) => {
+  if (!timestamp) return "-";
+  const date = new Date(timestamp);
+  return (
+    date.toLocaleDateString("en-PH", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+  );
+};
+
+/**
+ * Return a formatted date string from another timestamp string without the time.
+ * @param dateString Timestamp/date in string form.
+ */
+export const formatDateWithoutTime = (dateString?: string | null) => {
+  if (!dateString) return "-";
+  const date = new Date(dateString);
+  return (
+    date.toLocaleDateString("en-PH", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+  );
+};
+
+/**
  * Date formatter.
  *
  * @param dateString


### PR DESCRIPTION
This addresses a common issue where people try to select multiple applicants and accidentally go into the applicant view. Now, when you are in select mode, clicking anywhere in the whole row/card selects that applicant.