### PR TITLE
feat: collapse sidebar on medium screens

### DIFF
--- a/components/features/hire/content-layout.tsx
+++ b/components/features/hire/content-layout.tsx
@@ -72,7 +72,7 @@ function SideNav({ items }: { items: NavItem[] }) {
               )}
             >
               {icon}
-              <div className="sm:hidden lg:block">
+              <div className="hidden lg:block">
                 {label}
               </div>
             </Button>


### PR DESCRIPTION
On medium screens, we can save some space by collapsing the sidebar like how Twitter does it. We should experiment by having a label appear on hover.