### PR TITLE
refactor: split applications command bar and selection features

### DIFF
--- a/app/hire/dashboard/page.tsx
+++ b/app/hire/dashboard/page.tsx
@@ -59,8 +59,8 @@ function DashboardContent() {
             <>
               <div>
                 <div className="flex gap-4 mb-4">
-                  <span className="text-gray-500 pb-2"><span className="text-primary font-bold">{activeJobs.length}</span> active listing/s</span>
-                  <span className="text-gray-500 pb-2"><span className="text-primary font-bold">{inactiveJobs.length}</span> inactive listing/s</span>
+                  <span className="text-gray-500 pb-2"><span className="text-primary font-bold">{activeJobs.length}</span> active listing{activeJobs.length !== 1 ? "s" : ""}</span>
+                  <span className="text-gray-500 pb-2"><span className="text-primary font-bold">{inactiveJobs.length}</span> inactive listing{inactiveJobs.length !== 1 ? "s" : ""}</span>
                 </div>
                 <>
                   <JobsContent

--- a/components/features/hire/dashboard/ApplicationsCommandBar.tsx
+++ b/components/features/hire/dashboard/ApplicationsCommandBar.tsx
@@ -1,0 +1,136 @@
+import { ActionItem } from "@/components/ui/action-item";
+import { CommandMenu } from "@/components/ui/command-menu";
+import { useAppContext } from "@/lib/ctx-app";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckSquare, Trash, X } from "lucide-react";
+
+interface ApplicationsCommandBarProps {
+  visible: boolean,
+  selectedCount: number,
+  allVisibleSelected: boolean,
+  someVisibleSelected: boolean,
+  visibleApplicationsCount: number,
+  statuses: ActionItem[],
+  onUnselectAll: () => void,
+  onToggleSelectAll: () => void,
+  onDelete: () => void,
+  onStatusChange: () => void,
+}
+
+export function ApplicationsCommandBar({
+  visible,
+  selectedCount,
+  allVisibleSelected,
+  someVisibleSelected,
+  visibleApplicationsCount,
+  statuses,
+  onUnselectAll,
+  onToggleSelectAll,
+  onDelete,
+  onStatusChange,
+} : ApplicationsCommandBarProps) {
+  const { isMobile } = useAppContext();
+
+  return isMobile ? (
+    <AnimatePresence>
+      {visible && (
+        <>
+          <motion.div
+            className="fixed bottom-4 z-[1000] shadow-xl w-max"
+            initial={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+            animate={{ scale: 1, filter: "blur(0px)", opacity: 1, x: "-50%" }}
+            exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            style={{ left: "50%" }}
+          >
+            <CommandMenu
+              buttonLayout="vertical"
+              items={statuses}
+            />
+          </motion.div>
+          <motion.div
+            className="fixed top-20 z-[1000] shadow-xl w-max mx-2"
+            initial={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+            animate={{ scale: 1, filter: "blur(0px)", opacity: 1, x: "-50%" }}
+            exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            style={{ left: "50%" }}
+          >
+            <CommandMenu
+              buttonLayout="vertical"
+              items={[
+                [
+                  {
+                    id: "cancel",
+                    icon: X,
+                    onClick: onUnselectAll,
+                  },
+                  `${selectedCount} selected`,
+                ],
+                [
+                  {
+                    id: "select_all",
+                    label: allVisibleSelected ? "Unselect all" : "Select all" ,
+                    icon: CheckSquare,
+                    onClick: onToggleSelectAll,
+                  },
+                  {
+                    id: "delete",
+                    label: "Delete",
+                    icon: Trash,
+                    destructive: true,
+                    onClick: onDelete,
+                  },
+                ],
+              ]}
+            />
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  ) : (
+    <AnimatePresence>
+      {visible && (
+        <>
+        <motion.div
+          className="fixed bottom-4 z-[1000] shadow-xl w-max"
+          initial={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+          animate={{ scale: 1, filter: "blur(0px)", opacity: 1, x: "-50%", backdropFilter: "blur(50%)" }}
+          exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
+          style={{ left: "50%" }}
+        >
+          <CommandMenu
+            items={[
+              [
+                {
+                  id: "cancel",
+                  icon: X,
+                  onClick: onUnselectAll,
+                },
+                `${selectedCount} selected`,
+              ],
+              statuses,
+              [
+                {
+                  id: "select_all",
+                  label: allVisibleSelected ? "Unselect all" : "Select all" ,
+                  icon: CheckSquare,
+                  onClick: onToggleSelectAll,
+                },
+                {
+                  id: "delete",
+                  label: "Delete",
+                  icon: Trash,
+                  destructive: true,
+                  onClick: onDelete,
+                },
+              ],
+            ]}
+          />
+        </motion.div>
+      </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/use-application-selection.ts
+++ b/hooks/use-application-selection.ts
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { EmployerApplication } from "@/lib/db/db.types";
+
+/**
+ * Hook for handling application selection on the applicants page.
+ * @param applications Visible applications
+ */
+export function useApplicationSelection(applications: EmployerApplication[]) {
+  const [selectedApplications, setSelectedApplications] = useState<Set<string>>(new Set());
+
+  const toggleSelect = (id: string, next?: boolean) => {
+      setSelectedApplications((prev) => {
+        const nextSet = new Set(prev);
+        if (typeof next === "boolean") {
+          next ? nextSet.add(id) : nextSet.delete(id);
+        } else {
+          nextSet.has(id) ? nextSet.delete(id) : nextSet.add(id);
+        }
+  
+        return nextSet;
+      });
+    };
+  
+  const selectAll = () => {
+    // only select all visible applications.
+    setSelectedApplications(
+      new Set(applications.map((application) => application.id!))
+    )
+  };
+
+  const unselectAll = () => {
+    setSelectedApplications(new Set());
+  };
+
+  const toggleSelectAll = () => {
+    selectedApplications.size === applications.length ? unselectAll() : selectAll();
+  };
+
+  return {
+    selectedApplications,
+    toggleSelect,
+    selectAll,
+    unselectAll,
+    toggleSelectAll,
+  };
+}


### PR DESCRIPTION
In an effort to reduce the clutter in the `JobTabs` and `ApplicationsContent` components, I've split the command bars' display logic into its own sub-component and the selection feature into a hook. This also adds a confirmation modal when editing multiple applicants' status.