### PR TITLE
fix: chat page overflow

### DIFF
--- a/components/features/hire/chat/ConversationPage.tsx
+++ b/components/features/hire/chat/ConversationPage.tsx
@@ -216,7 +216,9 @@ export function ConversationPage({
     const hasConversations = (conversations.data?.length ?? 0) > 0;
 
     return (
-        <div className="w-full h-screen flex flex-col md:flex-row overflow-hidden">
+        <div 
+            className="w-full h-full flex flex-col md:flex-row"
+        >
             {hasConversations ? (
             <>
                 {/* ===== Left: List (Desktop always visible; Mobile only when in "list" view) ===== */}
@@ -257,7 +259,7 @@ export function ConversationPage({
                 {/* ===== Right: Chat (Desktop always visible; Mobile only when in "chat" view) ===== */}
                 <section
                 className={cn(
-                    "flex-1 flex flex-col md:max-w-[75%] h-full",
+                    "flex-1 flex flex-col h-full",
                     isMobile ? (mobileView === "chat" ? "flex" : "hidden") : "flex",
                 )}
                 >

--- a/components/features/hire/content-layout.tsx
+++ b/components/features/hire/content-layout.tsx
@@ -87,14 +87,14 @@ const ContentLayout: React.FC<ContentLayoutProps> = ({ children, className }) =>
   const { isMobile } = useMobile();
   
   return (
-    <div className="w-full flex flex-row space-x-0">
+    <div className="w-full h-full flex flex-row space-x-0">
       {!isMobile ? (
         <>
-          <aside className="absolute top-20 left-0 z-[100] h-screen border-r bg-muted">
-            <SideNav items={navItems} />
-          </aside>
-          {/* This is only here so the main tag below is offset */}
-          <aside className="h-screen w-fit invisible">
+          <aside 
+            className={cn(
+              "z-[100] min-h-stretch border-r bg-muted",
+            )}
+          >
             <SideNav items={navItems} />
           </aside>
         </>
@@ -102,7 +102,7 @@ const ContentLayout: React.FC<ContentLayoutProps> = ({ children, className }) =>
         <></>
       )} 
       <main className={cn(
-        "flex-1 flex overflow-auto justify-center mb-20 h-[100%] pt-4",
+        "flex-1 flex overflow-auto justify-center pt-4",
         isMobile ? "px-2" : "px-8",
         className
       )}>

--- a/components/features/hire/header.tsx
+++ b/components/features/hire/header.tsx
@@ -61,7 +61,7 @@ export const Header: React.FC = () => {
     <div className="flex flex-col">
       <div className={cn(
                 "flex justify-between items-center bg-white/80 backdrop-blur-md border-b border-gray-100 z-[90]",
-                isMobile ? "px-4 py-3" : "py-4 px-8"
+                isMobile ? "px-4 py-3 h-[4rem]" : "py-4 px-8 h-[5rem]"
               )}
               style={{ overflow: "visible", position: "relative", zIndex: 100 }}>
         <div className="flex items-center gap-3">


### PR DESCRIPTION
Made changes to the `ContentLayout` component to make it correctly calculate the height of the page. This, in turn, fixes two bugs:
- Overscroll on pages for no apparent reason
- Chat controls being hidden until the user scrolls
Upon initial testing, no issues were found from this change, but if you do find any, please feel free to tell me and I'll look into it.