### PR TITLE
fix: remove duplicate loader from applicants page

### DIFF
--- a/app/hire/dashboard/manage/page.tsx
+++ b/app/hire/dashboard/manage/page.tsx
@@ -46,7 +46,7 @@ function ManageContent() {
   if (loading || !jobData) {
     return (
       <ContentLayout>
-        <Loader>Loading dashboard...</Loader>
+        <Loader>Loading job...</Loader>
       </ContentLayout>
     );
   }

--- a/components/features/hire/dashboard/JobTabs.tsx
+++ b/components/features/hire/dashboard/JobTabs.tsx
@@ -385,7 +385,7 @@ export default function JobTabs({
   };
 
   if (isLoading || !isAuthenticated())
-    return <Loader>Loading job...</Loader>;
+    return null;
 
   let lastSelf: boolean = false;
 


### PR DESCRIPTION
Previously, there were separate "loading dashboard" and "loading job" loaders. This merges them into one "loading job" loader.