### PR TITLE
fix: infinite rerendering of education background

### DIFF
--- a/app/student/profile/page.tsx
+++ b/app/student/profile/page.tsx
@@ -1020,10 +1020,6 @@ const ProfileEditor = forwardRef<
     formData.university,
     formData.college,
     colleges,
-    get_colleges_by_university,
-    to_college_name,
-    setField,
-    to_university_name,
   ]);
 
   return (


### PR DESCRIPTION
The dependency list of the effect that updates the department based on university causes infinite re-rendering, resulting in a memory leak and high CPU usage. On locally-hosted instances where a cap is applied to the number of re-renders, this makes it very difficult to change university. I'm still looking into the side effects of removing these dependencies from the effect, but this does address the performance issue.