### PR TITLE
status and job deletion changes

### DIFF
--- a/app/hire/dashboard/page.tsx
+++ b/app/hire/dashboard/page.tsx
@@ -2,10 +2,8 @@
 // Wraps everything in DashboardProvider for shared state management
 "use client";
 
-import { motion } from "framer-motion";
 import ContentLayout from "@/components/features/hire/content-layout";
 import { JobsContent } from "@/components/features/hire/dashboard/JobsContent";
-import { ShowUnverifiedBanner } from "@/components/ui/banner";
 import { Loader } from "@/components/ui/loader";
 import {
   useEmployerApplications,
@@ -18,14 +16,11 @@ import { Bell, Briefcase, Plus } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { useAuthContext } from "../authctx";
 import { Job } from "@/lib/db/db.types";
-import { FadeIn } from "@/components/animata/fade";
 import { useModal } from "@/hooks/use-modal";
 import {
   getNotificationPermission,
   requestNotificationPermission,
   checkNotificationSupport,
-  shouldShowNotification,
-  sendNotification,
 } from "@/lib/notification-service";
 import { HeaderIcon, HeaderText } from "@/components/ui/text";
 import { useRouter } from "next/navigation";

--- a/app/hire/dashboard/page.tsx
+++ b/app/hire/dashboard/page.tsx
@@ -12,16 +12,10 @@ import {
 } from "@/hooks/use-employer-api";
 import { useMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
-import { Bell, Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { useAuthContext } from "../authctx";
 import { Job } from "@/lib/db/db.types";
-import { useModal } from "@/hooks/use-modal";
-import {
-  getNotificationPermission,
-  requestNotificationPermission,
-  checkNotificationSupport,
-} from "@/lib/notification-service";
 import { HeaderIcon, HeaderText } from "@/components/ui/text";
 import { useRouter } from "next/navigation";
 
@@ -71,28 +65,6 @@ function DashboardContent() {
     return result;
   };
 
-  const {
-    open: openNotifPermsModal,
-    close: closeNotifPermsModal,
-    Modal: NotifPermsModal,
-  } = useModal("notif-perms-modal");
-
-  useEffect(() => {
-    const requestPermission = async () => {
-      if (checkNotificationSupport()) {
-        const currentPermission = getNotificationPermission();
-
-        if (currentPermission === "default") {
-          openNotifPermsModal();
-          const permission = await requestNotificationPermission();
-          closeNotifPermsModal();
-        }
-      }
-    };
-
-    requestPermission();
-  }, []);
-
   useEffect(() => {
     if (!ownedJobs) {
       setLoading(true);
@@ -111,17 +83,6 @@ function DashboardContent() {
 
   return (
     <ContentLayout>
-      <NotifPermsModal>
-        <div className="p-8 pt-0 h-full">
-          <div className="text-lg mb-4">
-            <Bell size={48} />
-            <span>
-              Please grant notification access so we can send you chat
-              notifications.
-            </span>
-          </div>
-        </div>
-      </NotifPermsModal>
       <div
         className={cn(
           "flex-1 flex flex-col w-full py-4",
@@ -162,7 +123,7 @@ function DashboardContent() {
             {isMobile && (
               <button
                 aria-label="Create new listing"
-                className="fixed bottom-8 right-2 bg-primary rounded-full p-5 z-10 shadow-xl z-[1000]"
+                className="fixed bottom-8 right-2 bg-primary rounded-full p-5 z-10 shadow-xl"
                 onClick={handleAddListingClick}
               >
                 <Plus className="h-5 w-5 text-white" />

--- a/components/features/hire/dashboard/ApplicantPage.tsx
+++ b/components/features/hire/dashboard/ApplicantPage.tsx
@@ -39,6 +39,7 @@ import { Loader } from "@/components/ui/loader";
 import { motion } from "framer-motion";
 import { useAuthContext } from "@/app/hire/authctx";
 import { ActionButton } from "@/components/ui/action-button";
+import StatusBadge from "@/components/ui/status-badge";
 
 interface ApplicantPageProps {
   application: EmployerApplication | undefined;
@@ -306,7 +307,11 @@ export function ApplicantPage({
             {/* actions */}
             <div className="flex items-center justify-between gap-2 my-4">
               <div className="flex items-center gap-2">
-                <DropdownMenu items={statuses} defaultItem={defaultStatus} />
+                {filterKey !== "accepted" && filterKey !== "rejected" ? (
+                  <DropdownMenu items={statuses} defaultItem={defaultStatus} />
+                ) : (
+                  <StatusBadge statusId={application?.status || 0} />
+                )}
               </div>
               <div className="flex items-center gap-2">
                 {onArchive && (

--- a/components/features/hire/dashboard/ApplicationRow.tsx
+++ b/components/features/hire/dashboard/ApplicationRow.tsx
@@ -29,6 +29,7 @@ import {
 import { ActionButton } from "@/components/ui/action-button";
 import { FormCheckbox } from "@/components/EditForm";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
+import StatusBadge from "@/components/ui/status-badge";
 
 interface ApplicationRowProps {
   index?: number;
@@ -117,11 +118,7 @@ export function ApplicationRow({
             </h4>
           </div>
           {isSuperListing && (
-            <DropdownMenu
-              items={statuses}
-              defaultItem={defaultStatus}
-              enabled={application.status !== 4 && application.status !== 6}
-            />
+            <DropdownMenu items={statuses} defaultItem={defaultStatus} />
           )}
         </div>
         {isSuperListing ? (
@@ -167,11 +164,14 @@ export function ApplicationRow({
         )}
         {!isSuperListing && (
           <div className="flex items-center justify-end gap-2 pt-2">
-            <DropdownMenu
-              items={statuses}
-              defaultItem={defaultStatus}
-              enabled={application.status !== 4 && application.status !== 6}
-            />
+            {filterKey !== "accepted" && filterKey !== "rejected" ? (
+              <DropdownMenu items={statuses} defaultItem={defaultStatus} />
+            ) : (
+              <StatusBadge
+                className="w-32 py-2"
+                statusId={application.status || 0}
+              />
+            )}
           </div>
         )}
       </Card>
@@ -208,12 +208,15 @@ export function ApplicationRow({
           {formatDateWithoutTime(application.applied_at)}
         </td>
         <td className="px-4 py-2 w-40 overflow-visible">
-          <DropdownMenu
-            className="w-full"
-            items={statuses}
-            defaultItem={defaultStatus}
-            enabled={application.status !== 4 && application.status !== 6}
-          />
+          {filterKey !== "accepted" && filterKey !== "rejected" ? (
+            <DropdownMenu
+              className="w-full"
+              items={statuses}
+              defaultItem={defaultStatus}
+            />
+          ) : (
+            <StatusBadge statusId={application.status || 0} />
+          )}
         </td>
         <td>
           <div className="flex items-center gap-2 pr-2 flex-row justify-end">
@@ -307,11 +310,15 @@ export function ApplicationRow({
         {formatDateWithoutTime(application.applied_at)}
       </td>
       <td className="px-4 py-2 w-40 overflow-visible">
-        <DropdownMenu
-          items={statuses}
-          defaultItem={defaultStatus}
-          enabled={application.status !== 4 && application.status !== 6}
-        />
+        {filterKey !== "accepted" && filterKey !== "rejected" ? (
+          <DropdownMenu
+            className="w-full"
+            items={statuses}
+            defaultItem={defaultStatus}
+          />
+        ) : (
+          <StatusBadge statusId={application.status || 0} />
+        )}
       </td>
       <td>
         <div className="flex items-center gap-2 pr-2 flex-row justify-end">

--- a/components/features/hire/dashboard/JobHeader.tsx
+++ b/components/features/hire/dashboard/JobHeader.tsx
@@ -1,21 +1,20 @@
 import { Button } from "@/components/ui/button";
 import { Toggle } from "@/components/ui/toggle";
 import { useOwnedJobs } from "@/hooks/use-employer-api";
-import { useModal } from "@/hooks/use-modal";
 import { Job } from "@/lib/db/db.types";
 import { cn, formatDateWithoutTime } from "@/lib/utils";
 import { ArrowLeft, Edit, Info, Trash2, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
-import { ListingsDeleteModal } from "../listings";
 import { useListingsBusinessLogic } from "@/hooks/hire/listings/use-listings-business-logic";
 import { useAppContext } from "@/lib/ctx-app";
+import useModalRegistry from "@/components/modals/modal-registry";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { toast } from "sonner";
 
 export default function JobHeader({
   job,
@@ -25,29 +24,8 @@ export default function JobHeader({
   onJobUpdate?: (updates: Partial<Job>) => void;
 }) {
   const router = useRouter();
-  const [exitingBack, setExitingBack] = useState(false);
   const { ownedJobs, update_job, delete_job } = useOwnedJobs();
-  const [jobToDelete, setJobToDelete] = useState<Job | null>(null);
-  const { saving, clearSelectedJob } = useListingsBusinessLogic(ownedJobs);
-
-  const {
-    open: openDeleteModal,
-    close: closeDeleteModal,
-    Modal: DeleteModal,
-  } = useModal("delete-modal");
-
-  //goes back to job list
-  const handleJobBack = () => {
-    setExitingBack(true);
-    router.push("/dashboard");
-  };
-
-  const handleJobDelete = () => {
-    if (job) {
-      setJobToDelete(job);
-      openDeleteModal();
-    }
-  };
+  const { saving } = useListingsBusinessLogic(ownedJobs);
 
   const handleToggleActive = async () => {
     if (!job.id) return;
@@ -63,18 +41,10 @@ export default function JobHeader({
   const { isMobile } = useAppContext();
   const pathname = usePathname();
 
+  const modalRegistry = useModalRegistry();
+
   return (
     <div className="sticky top-0 z-40 border-b border-gray-200 bg-white shadow-sm">
-      <DeleteModal>
-        {jobToDelete && (
-          <ListingsDeleteModal
-            job={jobToDelete}
-            deleteJob={delete_job}
-            clearJob={clearSelectedJob}
-            close={closeDeleteModal}
-          />
-        )}
-      </DeleteModal>
       <div className="mx-auto px-4 md:px-6 py-3">
         <div
           className={cn(
@@ -106,7 +76,10 @@ export default function JobHeader({
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center gap-2">
-                  <Toggle state={job.is_active} onClick={handleToggleActive} />
+                  <Toggle
+                    state={job.is_active}
+                    onClick={() => void handleToggleActive}
+                  />
                   <span
                     className={cn(
                       "text-xs px-2 py-1 rounded transition",
@@ -188,7 +161,28 @@ export default function JobHeader({
               size="sm"
               disabled={saving}
               className="hover:bg-destructive/10 hover:text-destructive gap-1"
-              onClick={handleJobDelete}
+              onClick={() => {
+                modalRegistry.deleteListing.open({
+                  job,
+                  isProcessing: saving,
+                  onConfirm: () => {
+                    if (job.id) {
+                      void delete_job(job.id)
+                        .then(() => {
+                          modalRegistry.deleteListing.close();
+                          router.push("/dashboard");
+                          toast.success("Deleted job listing successfully.");
+                        })
+                        .catch((e: Error) => {
+                          modalRegistry.deleteListing.close();
+                          toast.error(
+                            e.message || "Failed to delete job listing.",
+                          );
+                        });
+                    }
+                  },
+                });
+              }}
             >
               <Trash2 size={16} />
               <span>Delete</span>

--- a/components/features/hire/listings/listings-delete-modal.tsx
+++ b/components/features/hire/listings/listings-delete-modal.tsx
@@ -42,7 +42,7 @@ export function ListingsDeleteModal({
           variant="outline"
           scheme="destructive"
           disabled={deleting}
-          onClick={handleDelete}
+          onClick={() => void handleDelete}
         >
           {deleting ? "Deleting..." : "Delete"}
         </Button>

--- a/components/modals/DeleteJobListingModal.tsx
+++ b/components/modals/DeleteJobListingModal.tsx
@@ -1,0 +1,50 @@
+import { Job } from "@/lib/db/db.types";
+import { Trash2 } from "lucide-react";
+import { HeaderIcon } from "../ui/text";
+import { Button } from "../ui/button";
+
+interface DeleteJobListingProps {
+  job: Job;
+  isProcessing: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteJobListingModal({
+  job,
+  isProcessing,
+  onConfirm,
+  onCancel,
+}: DeleteJobListingProps) {
+  if (!job) return null;
+
+  return (
+    <div className="flex flex-col gap-3 h-full w-full">
+      <div className="flex items-center gap-3 pt-4">
+        <HeaderIcon icon={Trash2} />
+        <h4>Delete {job.title}?</h4>
+      </div>
+      <span>This action is permanent and cannot be undone.</span>
+
+      {/* action buttons */}
+      <div className="flex justify-end gap-2 mt-auto pt-4 border-t">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          disabled={isProcessing}
+          className="w-full sm:w-auto"
+        >
+          Cancel
+        </Button>
+        <Button
+          scheme="destructive"
+          onClick={onConfirm}
+          disabled={isProcessing}
+          className="w-full sm:w-auto"
+        >
+          {isProcessing ? "Deleting job..." : "Delete"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/modals/modal-registry.tsx
+++ b/components/modals/modal-registry.tsx
@@ -22,6 +22,8 @@ import { IFormSigningParty } from "@betterinternship/core/forms";
 import { ApplicationAction } from "@/lib/consts/application";
 import { EmployerApplication } from "@/lib/db/db.types";
 import ApplicationActionModal from "./ApplicationActionModal";
+import DeleteJobListingModal from "./DeleteJobListingModal";
+import { Job } from "@/lib/db/db.types";
 
 /**
  * Simplifies modal config since we usually reuse each of these modal stuffs.
@@ -33,6 +35,36 @@ export const useModalRegistry = () => {
 
   const modalRegistry = useMemo(
     () => ({
+      // modal for deleting a job listing.
+      deleteListing: {
+        open: ({
+          job,
+          isProcessing,
+          onConfirm,
+        }: {
+          job: Job;
+          isProcessing: boolean;
+          onConfirm: () => void;
+        }) =>
+          open(
+            "delete-listing",
+            DefaultModalLayout,
+            <DeleteJobListingModal
+              job={job}
+              isProcessing={isProcessing}
+              onConfirm={onConfirm}
+              onCancel={() => close("delete-listing")}
+            />,
+            {
+              title: `Delete ${job.title}`,
+              closeOnBackdropClick: true,
+              closeOnEscapeKey: true,
+              showHeaderDivider: true,
+            },
+          ),
+        close: () => close("delete-listing"),
+      },
+      // modal for any action performed on a job application.
       applicationAction: {
         open: ({
           type,

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -4,9 +4,10 @@ import { DB_STATUS_MAP, UI_STATUS_MAP } from "@/lib/consts/application";
 
 interface StatusBadgeProps {
   statusId: number;
+  className?: string;
 }
 
-export default function StatusBadge({ statusId }: StatusBadgeProps) {
+export default function StatusBadge({ statusId, className }: StatusBadgeProps) {
   const config = DB_STATUS_MAP[statusId];
   const filterKey = config?.key || "pending";
   const status = UI_STATUS_MAP.get(filterKey);
@@ -19,9 +20,10 @@ export default function StatusBadge({ statusId }: StatusBadgeProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-1 w-full px-2 py-1 rounded-[0.33em] text-xs transition",
+        "flex items-center gap-1 w-full h-full px-2 py-1 border rounded-[0.33em] text-xs transition",
         status.bgColor,
         status.fgColor,
+        className,
       )}
     >
       <status.icon className="h-3 w-3" />


### PR DESCRIPTION
The status dropdown for each application row in the dashboard site has been changed to a badge for accepted and rejected applications to further reinforce that they cannot be clicked. The applicant page now follows this same system. Additionally, the job listing deletion modal has been migrated to the new system and has been given a `sonner` toast confirming deletion.