### PR TITLE
fix: toggle for job listing visibility not working

### DIFF
--- a/components/features/hire/dashboard/JobHeader.tsx
+++ b/components/features/hire/dashboard/JobHeader.tsx
@@ -78,7 +78,7 @@ export default function JobHeader({
                 <div className="flex items-center gap-2">
                   <Toggle
                     state={job.is_active}
-                    onClick={() => void handleToggleActive}
+                    onClick={() => void handleToggleActive()}
                   />
                   <span
                     className={cn(


### PR DESCRIPTION
Previously, employers were unable to disable/enable their job listing because the function for toggling its status was not called properly.