### PR TITLE
fix: crash on hire site

### DIFF
--- a/components/features/hire/dashboard/JobsContent.tsx
+++ b/components/features/hire/dashboard/JobsContent.tsx
@@ -45,8 +45,10 @@ export function JobsContent({
       return aIsSuper ? -1 : 1;
     }
 
-    const aCreatedAt = a.created_at?.getTime() ?? 0;
-    const bCreatedAt = b.created_at?.getTime() ?? 0;
+    console.log(typeof a.created_at);
+
+    const aCreatedAt = Date.parse(a?.created_at ?? "");
+    const bCreatedAt = Date.parse(b?.created_at ?? "");
     const aTimestamp = Number.isNaN(aCreatedAt) ? 0 : aCreatedAt;
     const bTimestamp = Number.isNaN(bCreatedAt) ? 0 : bCreatedAt;
 


### PR DESCRIPTION
Apparently the `created_at` field in the `Job` type is serialized as a string, but it's treated as a `Date` by the schema library. As such, I wrongly treated it as a `Date` in the `JobsContent` component. This reverts that change.