### PR TITLE
feat: selected jobs list

### DIFF
--- a/app/student/search/page.tsx
+++ b/app/student/search/page.tsx
@@ -30,6 +30,7 @@ import { Loader } from "@/components/ui/loader";
 import { motion, AnimatePresence } from "framer-motion";
 import type { ApplyPayload } from "@/components/modals/components/ApplyModal";
 import { toast } from "sonner";
+import { SearchCommandBar } from "@/components/features/student/search/SearchCommandBar";
 
 export default function SearchPage() {
   const searchParams = useSearchParams();
@@ -331,73 +332,21 @@ export default function SearchPage() {
       UI
     ====================================================================================== */
 
-  // page toolbar (floating action bar)
-  const FloatingActionBar = (
-    <AnimatePresence>
-      {selectMode && (
-        <motion.div
-          className="fixed bottom-6 z-50 bg-gray-100 border border-gray-300 rounded-lg shadow-lg px-6 py-4 flex items-center gap-4 w-fit max-w-[90vw] mx-auto left-0 right-0"
-          initial={{ scale: 0.95, opacity: 0, y: 20 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.95, opacity: 0, y: 20 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
-        >
-          <div className="flex items-center gap-3">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={selectAllOnPage}
-              className="h-8"
-            >
-              <CheckSquare className="w-4 h-4 mr-2" />
-              Select page
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={unselectAllOnPage}
-              className="h-8"
-            >
-              <Square className="w-4 h-4 mr-2" />
-              Unselect page
-            </Button>
-            <span className="text-sm text-gray-700 px-2">
-              {selectedIds.size} selected
-            </span>
-          </div>
-
-          <div className="h-6 w-px bg-gray-300" />
-
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              onClick={openMassApply}
-              className="h-8"
-              disabled={selectedIds.size === 0}
-            >
-              Apply to {selectedIds.size || 0}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8"
-              onClick={() => {
-                setSelectMode(false);
-                clearSelection();
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
-  );
-
   return (
     <>
       {/* Floating action bar */}
-      {!isMobile && FloatingActionBar}
+      <SearchCommandBar
+        visible={selectMode}
+        selected={selectedJobsList}
+        selectedCount={selectedJobsList.length}
+        onCancel={() => {
+          setSelectMode(false);
+          clearSelection();
+        }}
+        onUnselectPage={unselectAllOnPage}
+        onSelectPage={selectAllOnPage}
+        onApply={openMassApply}
+      />
 
       <div className="flex-1 flex overflow-hidden border-primary ">
         {jobs.isPending ? (
@@ -459,44 +408,6 @@ export default function SearchPage() {
                 />
               </div>
             </div>
-
-            {/* Mobile mass apply toolbar */}
-            {selectMode && (
-              <motion.div
-                className="fixed inset-x-0 bottom-0 z-50 min-h-16 bg-gray-50 border-t border-gray-200 shadow-lg px-4 py-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
-                initial={{ scale: 0.95, opacity: 0, y: 20 }}
-                animate={{ scale: 1, opacity: 1, y: 0 }}
-                exit={{ scale: 0.95, opacity: 0, y: 20 }}
-                transition={{ duration: 0.2, ease: "easeOut" }}
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-medium text-gray-700">
-                    {selectedIds.size} selected
-                  </span>
-                  <div className="flex gap-2">
-                    <Button
-                      size="sm"
-                      onClick={openMassApply}
-                      disabled={selectedIds.size === 0}
-                      className="h-8"
-                    >
-                      Apply ({selectedIds.size})
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-8"
-                      onClick={() => {
-                        setSelectMode(false);
-                        clearSelection();
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </motion.div>
-            )}
           </div>
         ) : (
           // Desktop split view

--- a/app/student/search/page.tsx
+++ b/app/student/search/page.tsx
@@ -346,6 +346,7 @@ export default function SearchPage() {
         onUnselectPage={unselectAllOnPage}
         onSelectPage={selectAllOnPage}
         onApply={openMassApply}
+        onToggleSelect={toggleSelect}
       />
 
       <div className="flex-1 flex overflow-hidden border-primary ">
@@ -397,7 +398,7 @@ export default function SearchPage() {
                 </div>
               )}
 
-              <div className="my-2">
+              <div className="my-4">
                 <Paginator
                   totalItems={jobs.filteredJobs.length}
                   itemsPerPage={jobsPageSize}
@@ -474,7 +475,7 @@ export default function SearchPage() {
                 </div>
               )}
 
-              <div className="mt-4">
+              <div className="mt-2 mb-8">
                 <Paginator
                   totalItems={jobs.filteredJobs.length}
                   itemsPerPage={jobsPageSize}

--- a/components/features/hire/dashboard/ApplicationsCommandBar.tsx
+++ b/components/features/hire/dashboard/ApplicationsCommandBar.tsx
@@ -33,32 +33,24 @@ export function ApplicationsCommandBar({
       {visible && (
         <>
           <motion.div
-            className="fixed bottom-4 z-[100] shadow-xl w-max overflow-hidden rounded-md"
-            initial={{
-              scale: 0.98,
-              filter: "blur(4px)",
-              opacity: 0,
-              x: "-50%",
-            }}
-            animate={{ scale: 1, filter: "blur(0px)", opacity: 1, x: "-50%" }}
-            exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
-            transition={{ duration: 0.3, ease: "easeOut" }}
-            style={{ left: "50%" }}
+            className="fixed left-0 bottom-0 z-[100] shadow-xl w-full overflow-hidden rounded-0.33em"
+            initial={{ y: "100%", filter: "blur(4px)" }}
+            animate={{ y: "0%", filter: "blur(0px)" }}
+            exit={{ y: "100%", filter: "blur(4px)" }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
           >
-            <CommandMenu buttonLayout="vertical" items={statuses} />
+            <CommandMenu
+              buttonLayout="vertical"
+              items={statuses}
+              className="w-full"
+            />
           </motion.div>
           <motion.div
-            className="fixed top-20 z-[100] shadow-xl w-max mx-2 overflow-hidden rounded-md"
-            initial={{
-              scale: 0.98,
-              filter: "blur(4px)",
-              opacity: 0,
-              x: "-50%",
-            }}
-            animate={{ scale: 1, filter: "blur(0px)", opacity: 1, x: "-50%" }}
-            exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
-            transition={{ duration: 0.3, ease: "easeOut" }}
-            style={{ left: "50%" }}
+            className="fixed left-0 top-0 z-[100] w-full overflow-hidden"
+            initial={{ y: "-100%", filter: "blur(4px)" }}
+            animate={{ y: "0%", filter: "blur(0px)" }}
+            exit={{ y: "-100%", filter: "blur(4px)" }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
           >
             <CommandMenu
               buttonLayout="vertical"
@@ -70,8 +62,6 @@ export function ApplicationsCommandBar({
                     onClick: onUnselectAll,
                   },
                   `${selectedCount} selected`,
-                ],
-                [
                   {
                     id: "select_all",
                     label: "Select all",
@@ -80,6 +70,7 @@ export function ApplicationsCommandBar({
                   },
                 ],
               ]}
+              className="w-full justify-between"
             />
           </motion.div>
         </>
@@ -90,23 +81,11 @@ export function ApplicationsCommandBar({
       {visible && (
         <>
           <motion.div
-            className="fixed bottom-4 z-[100] shadow-xl w-max overflow-hidden rounded-0.33em"
-            initial={{
-              scale: 0.98,
-              filter: "blur(4px)",
-              opacity: 0,
-              x: "-50%",
-            }}
-            animate={{
-              scale: 1,
-              filter: "blur(0px)",
-              opacity: 1,
-              x: "-50%",
-              backdropFilter: "blur(50%)",
-            }}
-            exit={{ scale: 0.98, filter: "blur(4px)", opacity: 0, x: "-50%" }}
-            transition={{ duration: 0.3, ease: "easeOut" }}
-            style={{ left: "50%" }}
+            className="fixed left-0 bottom-0 z-[100] w-full"
+            initial={{ y: "100%", filter: "blur(4px)" }}
+            animate={{ y: "0%", filter: "blur(0px)" }}
+            exit={{ y: "100%", filter: "blur(4px)" }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
           >
             <CommandMenu
               items={[

--- a/components/features/student/search/SearchCommandBar.tsx
+++ b/components/features/student/search/SearchCommandBar.tsx
@@ -1,0 +1,118 @@
+import { ActionItem } from "@/components/ui/action-item";
+import { CommandMenu } from "@/components/ui/command-menu";
+import { useAppContext } from "@/lib/ctx-app";
+import { Job } from "@/lib/db/db.types";
+import { motion, AnimatePresence } from "framer-motion";
+import { Check, CheckSquare, Square, X } from "lucide-react";
+
+interface SearchCommandBarProps {
+  visible: boolean;
+  selected: Job[];
+  selectedCount: number;
+  onCancel: () => void;
+  onUnselectPage: () => void;
+  onSelectPage: () => void;
+  onApply: () => void;
+}
+
+export function SearchCommandBar({
+  visible,
+  selected,
+  selectedCount,
+  onCancel,
+  onUnselectPage,
+  onSelectPage,
+  onApply,
+}: SearchCommandBarProps) {
+  const { isMobile } = useAppContext();
+
+  return isMobile ? (
+    <AnimatePresence>
+      {visible && (
+        <>
+          <motion.div
+            className="fixed left-0 bottom-0 z-[100] w-full"
+            initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+            animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
+            exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+          >
+            <CommandMenu
+              buttonLayout="vertical"
+              items={[
+                [`${selectedCount} selected`],
+                [
+                  {
+                    id: "apply",
+                    label: `Apply (${selectedCount})`,
+                    icon: Check,
+                    onClick: onApply,
+                    bgColor: "bg-primary/10",
+                    fgColor: "text-primary",
+                  },
+                  {
+                    id: "cancel",
+                    label: `Cancel`,
+                    icon: X,
+                    onClick: onCancel,
+                  },
+                ],
+              ]}
+            />
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  ) : (
+    <AnimatePresence>
+      {visible && (
+        <>
+          <motion.div
+            className="fixed left-0 bottom-0 z-[100] w-full"
+            initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+            animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
+            exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+          >
+            <CommandMenu
+              items={[
+                [
+                  {
+                    id: "cancel",
+                    icon: X,
+                    onClick: onCancel,
+                  },
+                  `${selectedCount} selected`,
+                ],
+                [
+                  {
+                    id: "select_all",
+                    label: "Select all",
+                    icon: CheckSquare,
+                    onClick: onSelectPage,
+                  },
+                  {
+                    id: "unselect_all",
+                    label: "Unselect all",
+                    icon: Square,
+                    onClick: onUnselectPage,
+                  },
+                ],
+                [
+                  {
+                    id: "apply",
+                    label: `Apply (${selectedCount})`,
+                    icon: Check,
+                    onClick: onApply,
+                    bgColor: "bg-primary/10",
+                    fgColor: "text-primary",
+                  },
+                ],
+              ]}
+            />
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/features/student/search/SearchCommandBar.tsx
+++ b/components/features/student/search/SearchCommandBar.tsx
@@ -1,9 +1,20 @@
+import { useState, useEffect } from "react";
 import { ActionItem } from "@/components/ui/action-item";
 import { CommandMenu } from "@/components/ui/command-menu";
 import { useAppContext } from "@/lib/ctx-app";
 import { Job } from "@/lib/db/db.types";
 import { motion, AnimatePresence } from "framer-motion";
-import { Check, CheckSquare, Square, X } from "lucide-react";
+import {
+  Check,
+  CheckSquare,
+  Square,
+  X,
+  PanelRight,
+  PanelRightClose,
+  List,
+} from "lucide-react";
+import { useBlurTransition } from "@/components/animata/blur";
+import { cn } from "@/lib/utils";
 
 interface SearchCommandBarProps {
   visible: boolean;
@@ -13,6 +24,46 @@ interface SearchCommandBarProps {
   onUnselectPage: () => void;
   onSelectPage: () => void;
   onApply: () => void;
+  onToggleSelect?: (job: Job) => void;
+}
+
+interface SelectedJobRowProps {
+  job: Job;
+  index: number;
+  onToggleSelect?: (job: Job) => void;
+}
+
+function SelectedJobRow({ job, index, onToggleSelect }: SelectedJobRowProps) {
+  const staggerDelay = index < 50 ? index * 0.05 : 0;
+  const blurTransition = useBlurTransition({ delay: staggerDelay });
+
+  return (
+    <motion.div
+      layout
+      key={job.id}
+      {...blurTransition}
+      className="group flex items-center justify-between p-3 rounded-[0.33em] border border-gray-100 hover:border-gray-200"
+    >
+      <div className="flex-1 min-w-0 pr-3">
+        <h4 className="font-heading font-medium text-gray-900 text-sm truncate group-hover:text-primary transition-colors">
+          {job.title}
+        </h4>
+        <p className="text-xs text-gray-500 truncate">
+          {job.employer?.name || "Unknown Company"}
+        </p>
+      </div>
+      {onToggleSelect && (
+        <button
+          type="button"
+          onClick={() => onToggleSelect(job)}
+          className="p-1 rounded hover:bg-muted text-muted-foreground  transition-all duration-200 shrink-0"
+          aria-label="Remove job"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </motion.div>
+  );
 }
 
 export function SearchCommandBar({
@@ -23,96 +74,171 @@ export function SearchCommandBar({
   onUnselectPage,
   onSelectPage,
   onApply,
+  onToggleSelect,
 }: SearchCommandBarProps) {
   const { isMobile } = useAppContext();
+  const [isOpen, setIsOpen] = useState(false);
 
-  return isMobile ? (
-    <AnimatePresence>
-      {visible && (
-        <>
-          <motion.div
-            className="fixed left-0 bottom-0 z-[100] w-full"
-            initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
-            animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
-            exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
-            transition={{ duration: 0.25, ease: "easeOut" }}
-          >
-            <CommandMenu
-              buttonLayout="vertical"
-              items={[
-                [`${selectedCount} selected`],
-                [
-                  {
-                    id: "apply",
-                    label: `Apply (${selectedCount})`,
-                    icon: Check,
-                    onClick: onApply,
-                    bgColor: "bg-primary/10",
-                    fgColor: "text-primary",
-                  },
-                  {
-                    id: "cancel",
-                    label: `Cancel`,
-                    icon: X,
-                    onClick: onCancel,
-                  },
-                ],
-              ]}
-            />
-          </motion.div>
-        </>
+  // Auto-close sidebar if command bar becomes invisible or count goes to 0
+  useEffect(() => {
+    if (!visible || selectedCount === 0) {
+      setIsOpen(false);
+    }
+  }, [visible, selectedCount]);
+
+  const renderSidebar = () => (
+    <motion.div
+      className="fixed right-0 top-0 md:top-20 bottom-14 md:bottom-12 w-full md:max-w-sm bg-white border-l border-gray-200 flex flex-col overflow-hidden z-[110]"
+      initial={{ x: "100%", filter: "blur(4px)", opacity: 0 }}
+      animate={{ x: "0%", filter: "blur(0px)", opacity: 1 }}
+      exit={{ x: "100%", filter: "blur(4px)", opacity: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+    >
+      {/* Sidebar Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-muted/50">
+        <div>
+          <h3 className="font-heading font-semibold text-base">
+            Selected Jobs
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {selectedCount} listing{selectedCount !== 1 ? "s" : ""} selected
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsOpen(false)}
+          className="p-1.5 rounded-[0.33em] hover:bg-muted text-muted-foreground transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Sidebar Content */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+        {selected.map((job, index) => (
+          <SelectedJobRow
+            key={job.id}
+            job={job}
+            index={index}
+            onToggleSelect={onToggleSelect}
+          />
+        ))}
+      </div>
+    </motion.div>
+  );
+
+  return (
+    <>
+      <AnimatePresence>{visible && isOpen && renderSidebar()}</AnimatePresence>
+
+      {isMobile ? (
+        <AnimatePresence>
+          {visible && (
+            <>
+              <motion.div
+                className="fixed left-0 bottom-0 z-[110] w-full"
+                initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+                animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
+                exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+                transition={{ duration: 0.25, ease: "easeOut" }}
+              >
+                <CommandMenu
+                  buttonLayout="vertical"
+                  items={[
+                    [
+                      `${selectedCount} selected`,
+                      {
+                        id: "apply",
+                        label: `Apply (${selectedCount})`,
+                        icon: Check,
+                        onClick: onApply,
+                        bgColor: "bg-primary/10",
+                        fgColor: "text-primary",
+                      },
+                      {
+                        id: "cancel",
+                        label: "Cancel",
+                        icon: X,
+                        onClick: onCancel,
+                      },
+                      {
+                        id: "job_list",
+                        label: "Selected jobs",
+                        icon: List,
+                        onClick: () => setIsOpen(!isOpen),
+                        highlighted: isOpen,
+                        highlightColor:
+                          "bg-primary/10 text-primary font-semibold",
+                      },
+                    ],
+                  ]}
+                />
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      ) : (
+        <AnimatePresence>
+          {visible && (
+            <>
+              <motion.div
+                className="fixed left-0 bottom-0 z-[110] w-full"
+                initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+                animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
+                exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
+                transition={{ duration: 0.25, ease: "easeOut" }}
+              >
+                <CommandMenu
+                  items={[
+                    [
+                      {
+                        id: "cancel",
+                        icon: X,
+                        onClick: onCancel,
+                      },
+                      `${selectedCount} selected`,
+                    ],
+                    [
+                      {
+                        id: "select_all",
+                        label: "Select all",
+                        icon: CheckSquare,
+                        onClick: onSelectPage,
+                      },
+                      {
+                        id: "unselect_all",
+                        label: "Unselect all",
+                        icon: Square,
+                        onClick: onUnselectPage,
+                      },
+                    ],
+                    [
+                      {
+                        id: "apply",
+                        label: `Apply (${selectedCount})`,
+                        icon: Check,
+                        onClick: onApply,
+                        bgColor: "bg-primary/10",
+                        fgColor: "text-primary",
+                      },
+                    ],
+                    [
+                      {
+                        id: "job_list",
+                        label: "Selected jobs",
+                        icon: isOpen ? PanelRightClose : PanelRight,
+                        onClick: () => setIsOpen(!isOpen),
+                        highlighted: isOpen,
+                        highlightColor: "bg-muted",
+                      },
+                    ],
+                  ]}
+                />
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
       )}
-    </AnimatePresence>
-  ) : (
-    <AnimatePresence>
-      {visible && (
-        <>
-          <motion.div
-            className="fixed left-0 bottom-0 z-[100] w-full"
-            initial={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
-            animate={{ y: "0%", filter: "blur(0px)", opacity: 1 }}
-            exit={{ y: "100%", filter: "blur(4px)", opacity: 0 }}
-            transition={{ duration: 0.25, ease: "easeOut" }}
-          >
-            <CommandMenu
-              items={[
-                [
-                  {
-                    id: "cancel",
-                    icon: X,
-                    onClick: onCancel,
-                  },
-                  `${selectedCount} selected`,
-                ],
-                [
-                  {
-                    id: "select_all",
-                    label: "Select all",
-                    icon: CheckSquare,
-                    onClick: onSelectPage,
-                  },
-                  {
-                    id: "unselect_all",
-                    label: "Unselect all",
-                    icon: Square,
-                    onClick: onUnselectPage,
-                  },
-                ],
-                [
-                  {
-                    id: "apply",
-                    label: `Apply (${selectedCount})`,
-                    icon: Check,
-                    onClick: onApply,
-                    bgColor: "bg-primary/10",
-                    fgColor: "text-primary",
-                  },
-                ],
-              ]}
-            />
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+    </>
   );
 }

--- a/components/ui/command-menu.tsx
+++ b/components/ui/command-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { cn } from "@/lib/utils";
 import { ActionItem } from "./action-item";
 
@@ -19,22 +19,18 @@ export const CommandMenu = ({
   className?: string;
 }) => {
   const isActionItem = (x: any): x is ActionItem =>
-    x &&
-    typeof x === "object" &&
-    typeof x.id === "string" &&
-    typeof x.onClick === "function";
+    x && typeof x === "object" && typeof x.id === "string";
 
-  const groups = (items && items.length > 0 && Array.isArray(items[0])) 
-    ? (items as Array<Array<ActionItem | string>>) 
-    : [items as Array<ActionItem | string>];
+  const groups =
+    items && items.length > 0 && Array.isArray(items[0])
+      ? (items as Array<Array<ActionItem | string>>)
+      : [items as Array<ActionItem | string>];
 
   const renderGroup = (group: Array<ActionItem | string>, idx: number) => {
     return (
       <React.Fragment key={idx}>
-        {idx > 0 && (
-          <div className="w-px bg-gray-300 my-1 mx-1" />
-        )}
-        {group.map((item, idx) => 
+        {idx > 0 && <div className="w-px bg-gray-300 my-1 mx-1" />}
+        {group.map((item, idx) =>
           isActionItem(item) ? (
             <button
               key={item.id}
@@ -48,10 +44,9 @@ export const CommandMenu = ({
                 item.destructive
                   ? "text-red-700 hover:bg-red-300/50 active:bg-red-400/75"
                   : "text-gray-700 hover:bg-gray-300/50 active:bg-gray-400/75",
-                item.highlighted
-                  ? item.highlightColor
-                  : "",
+                item.highlighted ? item.highlightColor : "",
                 item.fgColor,
+                item.bgColor,
               )}
             >
               {item.icon && <item.icon size={18} />}
@@ -62,12 +57,12 @@ export const CommandMenu = ({
               key={typeof item === "string" ? `text-${item}` : `node-${idx}`}
               className="flex justify-center items-center text-gray-700 px-2"
             >
-              {item as React.ReactNode}
+              {item}
             </span>
           ),
         )}
       </React.Fragment>
-    )
+    );
   };
 
   return (
@@ -75,7 +70,7 @@ export const CommandMenu = ({
       role="toolbar"
       onClick={(e) => e.stopPropagation()}
       className={cn(
-        "flex gap-4 px-6 py-2 justify-center items-stretch text-xs bg-white border border-gray-300 rounded-[0.33em] transition bg-clip-padding bg-clip-border",
+        "flex gap-4 px-6 py-2 w-full justify-center items-stretch text-xs bg-white border border-gray-300 transition bg-clip-border",
         className,
       )}
     >

--- a/components/ui/command-menu.tsx
+++ b/components/ui/command-menu.tsx
@@ -70,7 +70,7 @@ export const CommandMenu = ({
       role="toolbar"
       onClick={(e) => e.stopPropagation()}
       className={cn(
-        "flex gap-4 px-6 py-2 w-full justify-center items-stretch text-xs bg-white border border-gray-300 transition bg-clip-border",
+        "flex gap-4 px-6 py-2 w-full justify-center items-stretch text-xs bg-white border border-gray-200 transition bg-clip-border",
         className,
       )}
     >

--- a/lib/consts/application.ts
+++ b/lib/consts/application.ts
@@ -47,31 +47,34 @@ export const UI_STATUS_MAP = new Map<string, StatusProps>([
     "pending",
     {
       icon: Clock,
-      bgColor: "bg-orange-100",
-      fgColor: "text-orange-900",
+      bgColor: "bg-orange-700/10",
+      fgColor: "text-orange-700",
     },
   ],
   [
     "shortlisted",
-    { icon: Star, bgColor: "bg-amber-100", fgColor: "text-amber-900" },
+    { icon: Star, bgColor: "bg-amber-700/10", fgColor: "text-amber-700" },
   ],
   [
     "accepted",
-    { icon: Check, bgColor: "bg-green-100", fgColor: "text-green-900" },
+    { icon: Check, bgColor: "bg-green-700/10", fgColor: "text-green-700" },
   ],
   [
     "deleted",
     {
       icon: Trash,
-      bgColor: "bg-stone-200",
-      fgColor: "text-stone-900",
+      bgColor: "bg-stone-700/10",
+      fgColor: "text-stone-700",
       destructive: true,
     },
   ],
-  ["rejected", { icon: Ban, bgColor: "bg-red-100", fgColor: "text-red-900" }],
+  [
+    "rejected",
+    { icon: Ban, bgColor: "bg-red-700/10", fgColor: "text-red-700" },
+  ],
   [
     "archived",
-    { icon: Archive, bgColor: "bg-stone-200", fgColor: "text-stone-900" },
+    { icon: Archive, bgColor: "bg-stone-700/10", fgColor: "text-stone-700" },
   ],
 ]);
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/consts/**/*.{js,ts,jsx,tsx,mdx}",
     "*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {


### PR DESCRIPTION
Added a way to view selected jobs across different pages for the mass job apply feature. This is displayed in a sidebar that can be toggled from a button accessible through the mass apply command bar on the search page. This PR bundles the following changes as well:
- [fix] Colored labels not displaying on status buttons in the hire site's mass action command bar.
- [style] Updated the appearance of command bars to be "docked" to either the top or bottom of the screen.
- [refactor] The student site mass apply command bar now uses the `CommandMenu` component.