### PR TITLE
fix: disable mass hire actions conditionally

### DIFF
--- a/components/features/hire/dashboard/ApplicationsContent.tsx
+++ b/components/features/hire/dashboard/ApplicationsContent.tsx
@@ -27,19 +27,17 @@ import {
   UI_STATUS_MAP,
   ApplicationAction,
   ApplicationFilter,
+  LABEL_ID_STRING_MAP,
+  LABEL_ID_MAP,
 } from "@/lib/consts/application";
 import { type ActionItem } from "@/components/ui/action-item";
 import { ApplicationsCommandBar } from "./ApplicationsCommandBar";
 import { FormCheckbox } from "@/components/EditForm";
-import { DropdownMenu } from "@/components/ui/dropdown-menu";
-import { useRouter, useSearchParams } from "next/navigation";
 
 interface ApplicationsContentProps {
   applications: EmployerApplication[];
   isSuperListing?: boolean;
-  statusId: number[];
   isLoading?: boolean;
-  openChatModal: () => void;
   onApplicationClick: (application: EmployerApplication) => void;
   setSelectedApplication: (application: EmployerApplication) => void;
   onAction: (
@@ -47,8 +45,6 @@ interface ApplicationsContentProps {
     apps: EmployerApplication[],
     status?: number,
   ) => void;
-  applicantToDelete: EmployerApplication | null;
-  applicantToArchive: EmployerApplication | null;
 }
 
 export const ApplicationsContent = forwardRef<
@@ -59,7 +55,6 @@ export const ApplicationsContent = forwardRef<
     applications,
     isSuperListing = false,
     isLoading,
-    openChatModal,
     onApplicationClick,
     setSelectedApplication,
     onAction,
@@ -67,9 +62,6 @@ export const ApplicationsContent = forwardRef<
   ref,
 ) {
   const { isMobile } = useAppContext();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const selectedJobId = searchParams.get("jobId");
 
   const [commandBarsVisible, setCommandBarsVisible] = useState(false);
   const [activeFilter, setActiveFilter] = useState<ApplicationFilter>("all");
@@ -79,7 +71,7 @@ export const ApplicationsContent = forwardRef<
       new Date(a.applied_at ?? "").getTime(),
   );
 
-  const { app_statuses, get_app_status } = useDbRefs();
+  const { app_statuses } = useDbRefs();
 
   if (!app_statuses) return null;
 
@@ -173,6 +165,7 @@ export const ApplicationsContent = forwardRef<
 
   const {
     selectedApplications,
+    selectedApplicationsData,
     toggleSelect,
     selectAll,
     unselectAll,
@@ -194,10 +187,21 @@ export const ApplicationsContent = forwardRef<
   const someVisibleSelected =
     numVisibleSelected > 0 && numVisibleSelected < visibleApplications.length;
 
-  // separate statuses and visibility in the command bar and remove unused ones.
-  const command_bar_statuses = statuses.filter(
-    (status) => status.id !== "5" && status.id !== "7" && status.id !== "0",
+  const selectedAcceptedOrRejected = selectedApplicationsData.find(
+    (app) =>
+      app.status === LABEL_ID_MAP.get("accepted") ||
+      app.status === LABEL_ID_MAP.get("rejected"),
   );
+
+  // separate statuses and visibility in the command bar and remove unused ones.
+  const command_bar_statuses = selectedAcceptedOrRejected
+    ? ["Status locked for accepted/rejected applications."]
+    : statuses.filter(
+        (status) =>
+          status.id !== LABEL_ID_STRING_MAP.get("archived") &&
+          status.id !== LABEL_ID_STRING_MAP.get("deleted") &&
+          status.id !== LABEL_ID_STRING_MAP.get("pending"),
+      );
 
   const command_bar_visibility: ActionItem[] = [
     {

--- a/hooks/use-application-selection.ts
+++ b/hooks/use-application-selection.ts
@@ -6,26 +6,32 @@ import { EmployerApplication } from "@/lib/db/db.types";
  * @param applications Visible applications
  */
 export function useApplicationSelection(applications: EmployerApplication[]) {
-  const [selectedApplications, setSelectedApplications] = useState<Set<string>>(new Set());
+  const [selectedApplications, setSelectedApplications] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const selectedApplicationsData = applications.filter((app) =>
+    selectedApplications.has(app.id!),
+  );
 
   const toggleSelect = (id: string, next?: boolean) => {
-      setSelectedApplications((prev) => {
-        const nextSet = new Set(prev);
-        if (typeof next === "boolean") {
-          next ? nextSet.add(id) : nextSet.delete(id);
-        } else {
-          nextSet.has(id) ? nextSet.delete(id) : nextSet.add(id);
-        }
-  
-        return nextSet;
-      });
-    };
-  
+    setSelectedApplications((prev) => {
+      const nextSet = new Set(prev);
+      if (typeof next === "boolean") {
+        next ? nextSet.add(id) : nextSet.delete(id);
+      } else {
+        nextSet.has(id) ? nextSet.delete(id) : nextSet.add(id);
+      }
+
+      return nextSet;
+    });
+  };
+
   const selectAll = () => {
     // only select all visible applications.
     setSelectedApplications(
-      new Set(applications.map((application) => application.id!))
-    )
+      new Set(applications.map((application) => application.id!)),
+    );
   };
 
   const unselectAll = () => {
@@ -33,11 +39,14 @@ export function useApplicationSelection(applications: EmployerApplication[]) {
   };
 
   const toggleSelectAll = () => {
-    selectedApplications.size === applications.length ? unselectAll() : selectAll();
+    selectedApplications.size === applications.length
+      ? unselectAll()
+      : selectAll();
   };
 
   return {
     selectedApplications,
+    selectedApplicationsData,
     toggleSelect,
     selectAll,
     unselectAll,

--- a/lib/consts/application.ts
+++ b/lib/consts/application.ts
@@ -92,3 +92,21 @@ export const DB_STATUS_MAP: Record<number, StatusConfig> = {
   6: { key: "rejected", action: "REJECT" },
   7: { key: "archived", action: "ARCHIVE" },
 };
+
+export const LABEL_ID_STRING_MAP = new Map<string, string>([
+  ["pending", "0"],
+  ["shortlisted", "1"],
+  ["accepted", "4"],
+  ["deleted", "5"],
+  ["rejected", "6"],
+  ["archived", "7"],
+]);
+
+export const LABEL_ID_MAP = new Map<string, number>([
+  ["pending", 0],
+  ["shortlisted", 1],
+  ["accepted", 4],
+  ["deleted", 5],
+  ["rejected", 6],
+  ["archived", 7],
+]);


### PR DESCRIPTION
Fixes a longstanding bug wherein mass application actions on the employer site would incorrectly allow you to attempt to change the status of an application that had previously been marked as accepted or rejected. The database would not allow the change to push through, but a success dialog would incorrectly pop up. This now displays a message in the command bar to inform the user that the status buttons are disabled.