### PR TITLE
fix: add cloudflare to script csp exceptions

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,7 +37,7 @@ const imageOrigins = apiUrls
 
 const cspHeader = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdnjs.cloudflare.com;
   frame-src 'self' http://localhost:* ${connectOrigins};
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' blob: data: http://localhost:* ${imageOrigins};


### PR DESCRIPTION
Form previews were not working. Loosened CSP to allow CloudFlare's PDF lib through.