### PR TITLE
Feat/digest unsub

### DIFF
--- a/components/features/hire/account/digest-optout-dialog.tsx
+++ b/components/features/hire/account/digest-optout-dialog.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   useDeactivateBulkJobs,
@@ -19,39 +11,33 @@ import {
 } from "@/hooks/use-employer-api";
 import type { EligibleListing } from "@/lib/api/services";
 
-interface DigestOptoutDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+interface DigestOptoutModalContentProps {
   companyName: string;
   listings: EligibleListing[];
-  /** Called after either action succeeds, so the caller can refetch whatever it needs (owned jobs, /me). */
+  /** Called after either action succeeds, so the caller can refetch whatever it needs (owned jobs, /me) and close the modal. */
   onDone: () => void;
 }
 
 /**
  * Warns before a digest opt-out would leave every active listing silently
- * unattended (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §7.1). Mount-agnostic
- * (D14): only mounted from the Notifications tab today, but takes its data as
- * props so a future per-teammate toggle (§7.3) can reuse it unchanged.
+ * unattended (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §7.1). Content only
+ * — mounted through useModalRegistry().digestOptout (modal-registry.tsx) so it
+ * gets the app's shared backdrop/panel chrome instead of a bespoke one, and is
+ * mount-agnostic (D14): a future per-teammate toggle (§7.3) can open it the
+ * same way from the Team tab.
  */
-export function DigestOptoutDialog({
-  open,
-  onOpenChange,
+export function DigestOptoutModalContent({
   companyName,
   listings,
   onDone,
-}: DigestOptoutDialogProps) {
+}: DigestOptoutModalContentProps) {
+  // Unticked by default (D11) — a fresh mount every time the registry opens
+  // this modal, so there's no stale selection to reset between opens.
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const deactivateBulk = useDeactivateBulkJobs();
   const updateNotifications = useUpdateMyNotifications();
 
-  // Boxes start unticked every time the dialog is (re-)opened with a new set (D11).
-  useEffect(() => {
-    if (open) setCheckedIds(new Set());
-  }, [open]);
-
-  const allChecked =
-    listings.length > 0 && checkedIds.size === listings.length;
+  const allChecked = listings.length > 0 && checkedIds.size === listings.length;
   const pending = deactivateBulk.isPending || updateNotifications.isPending;
 
   const toggleAll = () => {
@@ -81,7 +67,6 @@ export function DigestOptoutDialog({
       toast.success(
         `Closed ${closedCount} listing${closedCount === 1 ? "" : "s"}. You'll still get applicant emails for the rest.`,
       );
-      onOpenChange(false);
       onDone();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Could not close listings.");
@@ -100,90 +85,90 @@ export function DigestOptoutDialog({
         );
         return;
       }
-      const closedCount = response.closed_listing_ids?.length ?? listings.length;
+      const closedCount =
+        response.closed_listing_ids?.length ?? listings.length;
       toast.success(
         `Applicant emails are off. ${closedCount} listing${closedCount === 1 ? "" : "s"} closed.`,
       );
-      onOpenChange(false);
       onDone();
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Could not update notification settings.",
+        e instanceof Error
+          ? e.message
+          : "Could not update notification settings.",
       );
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Turn off applicant emails?</DialogTitle>
-        </DialogHeader>
+    <div className="flex flex-col gap-3 pt-4">
+      <p className="text-sm text-gray-600">
+        You&apos;re the only person at {companyName} receiving emails.
+        <br />
+        Turning them off will also close{" "}
+        {listings.length === 1
+          ? "your active listing."
+          : `all ${listings.length} of your active listings.`}
+      </p>
 
-        <p className="text-sm text-muted-foreground">
-          You&apos;re the only person at {companyName} receiving these.
-          Turning them off will also close{" "}
-          {listings.length === 1
-            ? "your active listing."
-            : `all ${listings.length} of your active listings.`}
-        </p>
+      {/* A toolbar, not a list row: no checkbox, opposite alignment, and an
+          accent-colored action so it can't be mistaken for one of the items
+          below it. */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-600">
+          {checkedIds.size > 0
+            ? `${checkedIds.size} of ${listings.length} selected`
+            : `${listings.length} active listing${listings.length === 1 ? "" : "s"}`}
+        </span>
+        <button
+          type="button"
+          onClick={toggleAll}
+          className="cursor-pointer text-sm font-medium text-primary hover:underline"
+        >
+          {allChecked ? "Deselect all" : "Select all"}
+        </button>
+      </div>
 
-        <div className="rounded-md border">
-          <div className="flex items-center gap-2 border-b px-3 py-2">
-            <Checkbox
-              id="digest-optout-select-all"
-              checked={allChecked}
-              onCheckedChange={toggleAll}
-            />
-            <Label
-              htmlFor="digest-optout-select-all"
-              className="cursor-pointer text-sm font-medium text-gray-900"
+      <ScrollArea className="max-h-56 rounded-[0.33em] border">
+        <div className="divide-y">
+          {listings.map((listing) => (
+            <label
+              key={listing.id}
+              htmlFor={`digest-optout-${listing.id}`}
+              className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm"
             >
-              Select all ({listings.length})
-            </Label>
-          </div>
-          <ScrollArea className="max-h-56">
-            <div className="divide-y">
-              {listings.map((listing) => (
-                <label
-                  key={listing.id}
-                  htmlFor={`digest-optout-${listing.id}`}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm"
-                >
-                  <Checkbox
-                    id={`digest-optout-${listing.id}`}
-                    checked={checkedIds.has(listing.id)}
-                    onCheckedChange={() => toggleOne(listing.id)}
-                  />
-                  {listing.title}
-                </label>
-              ))}
-            </div>
-          </ScrollArea>
+              <Checkbox
+                id={`digest-optout-${listing.id}`}
+                checked={checkedIds.has(listing.id)}
+                onCheckedChange={() => toggleOne(listing.id)}
+              />
+              {listing.title}
+            </label>
+          ))}
         </div>
+      </ScrollArea>
 
-        <DialogFooter className="flex-col items-stretch gap-2 sm:flex-col sm:items-stretch sm:space-x-0">
-          <Button
-            className="w-full cursor-pointer"
-            disabled={checkedIds.size === 0 || pending}
-            onClick={handleCloseSelected}
-          >
-            {deactivateBulk.isPending
-              ? "Closing..."
-              : "Close only these listings"}
-          </Button>
-          <Button
-            variant="ghost"
-            className="w-full cursor-pointer text-muted-foreground"
-            disabled={pending}
-            onClick={handleTurnOffAnyway}
-          >
-            {updateNotifications.isPending
-              ? "Turning off..."
-              : "Turn off all emails anyway"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <div className="mt-3 flex flex-col gap-1">
+        <Button
+          variant="outline"
+          className="w-full cursor-pointer text-muted-foreground"
+          disabled={pending}
+          onClick={handleTurnOffAnyway}
+        >
+          {updateNotifications.isPending
+            ? "Turning off..."
+            : "Close all listings and turn off emails"}
+        </Button>
+        <Button
+          className="w-full cursor-pointer"
+          disabled={checkedIds.size === 0 || pending}
+          onClick={handleCloseSelected}
+        >
+          {deactivateBulk.isPending
+            ? "Closing..."
+            : "Close only these listings"}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/components/features/hire/account/digest-optout-dialog.tsx
+++ b/components/features/hire/account/digest-optout-dialog.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  useDeactivateBulkJobs,
+  useUpdateMyNotifications,
+} from "@/hooks/use-employer-api";
+import type { EligibleListing } from "@/lib/api/services";
+
+interface DigestOptoutDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyName: string;
+  listings: EligibleListing[];
+  /** Called after either action succeeds, so the caller can refetch whatever it needs (owned jobs, /me). */
+  onDone: () => void;
+}
+
+/**
+ * Warns before a digest opt-out would leave every active listing silently
+ * unattended (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §7.1). Mount-agnostic
+ * (D14): only mounted from the Notifications tab today, but takes its data as
+ * props so a future per-teammate toggle (§7.3) can reuse it unchanged.
+ */
+export function DigestOptoutDialog({
+  open,
+  onOpenChange,
+  companyName,
+  listings,
+  onDone,
+}: DigestOptoutDialogProps) {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+  const deactivateBulk = useDeactivateBulkJobs();
+  const updateNotifications = useUpdateMyNotifications();
+
+  // Boxes start unticked every time the dialog is (re-)opened with a new set (D11).
+  useEffect(() => {
+    if (open) setCheckedIds(new Set());
+  }, [open]);
+
+  const allChecked =
+    listings.length > 0 && checkedIds.size === listings.length;
+  const pending = deactivateBulk.isPending || updateNotifications.isPending;
+
+  const toggleAll = () => {
+    setCheckedIds(allChecked ? new Set() : new Set(listings.map((l) => l.id)));
+  };
+
+  const toggleOne = (id: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleCloseSelected = async () => {
+    const ids = [...checkedIds];
+    if (!ids.length) return;
+
+    try {
+      const response = await deactivateBulk.mutateAsync(ids);
+      if (!response.success) {
+        toast.error(response.message || "Could not close listings.");
+        return;
+      }
+      const closedCount = response.job_ids?.length ?? 0;
+      toast.success(
+        `Closed ${closedCount} listing${closedCount === 1 ? "" : "s"}. You'll still get applicant emails for the rest.`,
+      );
+      onOpenChange(false);
+      onDone();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not close listings.");
+    }
+  };
+
+  const handleTurnOffAnyway = async () => {
+    try {
+      const response = await updateNotifications.mutateAsync({
+        receivesDigest: false,
+        closeActiveListings: true,
+      });
+      if (!response.success) {
+        toast.error(
+          response.message || "Could not update notification settings.",
+        );
+        return;
+      }
+      const closedCount = response.closed_listing_ids?.length ?? listings.length;
+      toast.success(
+        `Applicant emails are off. ${closedCount} listing${closedCount === 1 ? "" : "s"} closed.`,
+      );
+      onOpenChange(false);
+      onDone();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Could not update notification settings.",
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Turn off applicant emails?</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground">
+          You&apos;re the only person at {companyName} receiving these.
+          Turning them off will also close{" "}
+          {listings.length === 1
+            ? "your active listing."
+            : `all ${listings.length} of your active listings.`}
+        </p>
+
+        <div className="rounded-md border">
+          <div className="flex items-center gap-2 border-b px-3 py-2">
+            <Checkbox
+              id="digest-optout-select-all"
+              checked={allChecked}
+              onCheckedChange={toggleAll}
+            />
+            <Label
+              htmlFor="digest-optout-select-all"
+              className="cursor-pointer text-sm font-medium text-gray-900"
+            >
+              Select all ({listings.length})
+            </Label>
+          </div>
+          <ScrollArea className="max-h-56">
+            <div className="divide-y">
+              {listings.map((listing) => (
+                <label
+                  key={listing.id}
+                  htmlFor={`digest-optout-${listing.id}`}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm"
+                >
+                  <Checkbox
+                    id={`digest-optout-${listing.id}`}
+                    checked={checkedIds.has(listing.id)}
+                    onCheckedChange={() => toggleOne(listing.id)}
+                  />
+                  {listing.title}
+                </label>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <DialogFooter className="flex-col items-stretch gap-2 sm:flex-col sm:items-stretch sm:space-x-0">
+          <Button
+            className="w-full cursor-pointer"
+            disabled={checkedIds.size === 0 || pending}
+            onClick={handleCloseSelected}
+          >
+            {deactivateBulk.isPending
+              ? "Closing..."
+              : "Close only these listings"}
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full cursor-pointer text-muted-foreground"
+            disabled={pending}
+            onClick={handleTurnOffAnyway}
+          >
+            {updateNotifications.isPending
+              ? "Turning off..."
+              : "Turn off all emails anyway"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/features/hire/account/notifications-tab.tsx
+++ b/components/features/hire/account/notifications-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -10,7 +10,7 @@ import {
   useProfile,
   useUpdateMyNotifications,
 } from "@/hooks/use-employer-api";
-import { DigestOptoutDialog } from "./digest-optout-dialog";
+import { useModalRegistry } from "@/components/modals/modal-registry";
 import type { EligibleListing } from "@/lib/api/services";
 
 export function NotificationsTab() {
@@ -18,9 +18,7 @@ export function NotificationsTab() {
   const { data: employer } = useProfile();
   const { ownedJobs, refetch: refetchOwnedJobs } = useOwnedJobs();
   const updateNotifications = useUpdateMyNotifications();
-  const [dialogListings, setDialogListings] = useState<EligibleListing[] | null>(
-    null,
-  );
+  const modalRegistry = useModalRegistry();
 
   // Client-side estimate for display only — the server always re-derives the
   // authoritative eligible set at confirm time (plan §6.3/§7.2).
@@ -39,6 +37,14 @@ export function NotificationsTab() {
     return <Card className="p-6 text-sm text-muted-foreground">Loading...</Card>;
   }
 
+  const openOptoutDialog = (listings: EligibleListing[]) => {
+    modalRegistry.digestOptout.open({
+      companyName: employer?.name || "your company",
+      listings,
+      onDone: () => refetchOwnedJobs(),
+    });
+  };
+
   const handleCheckedChange = async (checked: boolean) => {
     if (checked) {
       // Turning the digest on never warns (D7/D8 only gate turning it off).
@@ -55,49 +61,34 @@ export function NotificationsTab() {
         receivesDigest: false,
       });
       if (result.eligible_listings?.length) {
-        setDialogListings(result.eligible_listings);
+        openOptoutDialog(result.eligible_listings);
       }
       return;
     }
 
     // Last subscriber with active listings — nothing is written until the
     // dialog resolves (D5).
-    setDialogListings(eligibleListings);
-  };
-
-  const handleDialogDone = () => {
-    setDialogListings(null);
-    refetchOwnedJobs();
+    openOptoutDialog(eligibleListings);
   };
 
   return (
-    <>
-      <Card className="p-5">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <Label htmlFor="applicant-digest" className="text-sm font-medium text-gray-900">
-              Daily applicant digest
-            </Label>
-            <p className="text-sm text-muted-foreground mt-1">
-              Get an email whenever your listings receive new applicants.
-            </p>
-          </div>
-          <Switch
-            id="applicant-digest"
-            checked={me.receives_applicant_digest}
-            disabled={updateNotifications.isPending}
-            onCheckedChange={handleCheckedChange}
-          />
+    <Card className="p-5">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <Label htmlFor="applicant-digest" className="text-sm font-medium text-gray-900">
+            Daily applicant digest
+          </Label>
+          <p className="text-sm text-muted-foreground mt-1">
+            Get an email whenever your listings receive new applicants.
+          </p>
         </div>
-      </Card>
-
-      <DigestOptoutDialog
-        open={dialogListings !== null}
-        onOpenChange={(open) => !open && setDialogListings(null)}
-        companyName={employer?.name || "your company"}
-        listings={dialogListings ?? []}
-        onDone={handleDialogDone}
-      />
-    </>
+        <Switch
+          id="applicant-digest"
+          checked={me.receives_applicant_digest}
+          disabled={updateNotifications.isPending}
+          onCheckedChange={handleCheckedChange}
+        />
+      </div>
+    </Card>
   );
 }

--- a/components/features/hire/account/notifications-tab.tsx
+++ b/components/features/hire/account/notifications-tab.tsx
@@ -1,36 +1,103 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { useMe, useUpdateMyNotifications } from "@/hooks/use-employer-api";
+import {
+  useMe,
+  useOwnedJobs,
+  useProfile,
+  useUpdateMyNotifications,
+} from "@/hooks/use-employer-api";
+import { DigestOptoutDialog } from "./digest-optout-dialog";
+import type { EligibleListing } from "@/lib/api/services";
 
 export function NotificationsTab() {
   const { loading, data: me } = useMe();
+  const { data: employer } = useProfile();
+  const { ownedJobs, refetch: refetchOwnedJobs } = useOwnedJobs();
   const updateNotifications = useUpdateMyNotifications();
+  const [dialogListings, setDialogListings] = useState<EligibleListing[] | null>(
+    null,
+  );
+
+  // Client-side estimate for display only — the server always re-derives the
+  // authoritative eligible set at confirm time (plan §6.3/§7.2).
+  const eligibleListings = useMemo<EligibleListing[]>(
+    () =>
+      ownedJobs
+        .filter((job) => job.is_active === true && !job.paused)
+        .map((job) => ({
+          id: job.id as string,
+          title: job.title || "Untitled listing",
+        })),
+    [ownedJobs],
+  );
 
   if (loading || !me) {
     return <Card className="p-6 text-sm text-muted-foreground">Loading...</Card>;
   }
 
+  const handleCheckedChange = async (checked: boolean) => {
+    if (checked) {
+      // Turning the digest on never warns (D7/D8 only gate turning it off).
+      updateNotifications.mutate({ receivesDigest: true });
+      return;
+    }
+
+    const isLastSubscriber = (me.other_subscribed_recipients ?? 0) === 0;
+    if (!isLastSubscriber || eligibleListings.length === 0) {
+      // Safe to apply directly — but this is also the stale-client safety
+      // net: if the server's fresher count disagrees, it 409s with its own
+      // listing set instead of applying, and that set is what we show.
+      const result = await updateNotifications.mutateAsync({
+        receivesDigest: false,
+      });
+      if (result.eligible_listings?.length) {
+        setDialogListings(result.eligible_listings);
+      }
+      return;
+    }
+
+    // Last subscriber with active listings — nothing is written until the
+    // dialog resolves (D5).
+    setDialogListings(eligibleListings);
+  };
+
+  const handleDialogDone = () => {
+    setDialogListings(null);
+    refetchOwnedJobs();
+  };
+
   return (
-    <Card className="p-5">
-      <div className="flex items-center justify-between gap-4">
-        <div>
-          <Label htmlFor="applicant-digest" className="text-sm font-medium text-gray-900">
-            Daily applicant digest
-          </Label>
-          <p className="text-sm text-muted-foreground mt-1">
-            Get an email whenever your listings receive new applicants.
-          </p>
+    <>
+      <Card className="p-5">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <Label htmlFor="applicant-digest" className="text-sm font-medium text-gray-900">
+              Daily applicant digest
+            </Label>
+            <p className="text-sm text-muted-foreground mt-1">
+              Get an email whenever your listings receive new applicants.
+            </p>
+          </div>
+          <Switch
+            id="applicant-digest"
+            checked={me.receives_applicant_digest}
+            disabled={updateNotifications.isPending}
+            onCheckedChange={handleCheckedChange}
+          />
         </div>
-        <Switch
-          id="applicant-digest"
-          checked={me.receives_applicant_digest}
-          disabled={updateNotifications.isPending}
-          onCheckedChange={(checked) => updateNotifications.mutate(checked)}
-        />
-      </div>
-    </Card>
+      </Card>
+
+      <DigestOptoutDialog
+        open={dialogListings !== null}
+        onOpenChange={(open) => !open && setDialogListings(null)}
+        companyName={employer?.name || "your company"}
+        listings={dialogListings ?? []}
+        onDone={handleDialogDone}
+      />
+    </>
   );
 }

--- a/components/features/hire/account/notifications-tab.tsx
+++ b/components/features/hire/account/notifications-tab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -82,12 +83,17 @@ export function NotificationsTab() {
             Get an email whenever your listings receive new applicants.
           </p>
         </div>
-        <Switch
-          id="applicant-digest"
-          checked={me.receives_applicant_digest}
-          disabled={updateNotifications.isPending}
-          onCheckedChange={handleCheckedChange}
-        />
+        <div className="flex items-center gap-2">
+          {updateNotifications.isPending && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+          )}
+          <Switch
+            id="applicant-digest"
+            checked={me.receives_applicant_digest}
+            disabled={updateNotifications.isPending}
+            onCheckedChange={handleCheckedChange}
+          />
+        </div>
       </div>
     </Card>
   );

--- a/components/features/hire/dashboard/JobHeader.tsx
+++ b/components/features/hire/dashboard/JobHeader.tsx
@@ -31,6 +31,7 @@ export default function JobHeader({
   const { ownedJobs, update_job, delete_job, unpause_job } = useOwnedJobs();
   const { saving } = useListingsBusinessLogic(ownedJobs);
   const [reEnabling, setReEnabling] = useState(false);
+  const [togglingActive, setTogglingActive] = useState(false);
   const openNotificationsRequiredModal = useNotificationsRequiredModal();
 
   const handleBack = () => {
@@ -40,16 +41,20 @@ export default function JobHeader({
 
   const handleToggleActive = async () => {
     if (!job.id || job.paused) return;
+    setTogglingActive(true);
+    try {
+      const updates = { is_active: !job.is_active };
+      const result = await update_job(job.id, updates);
 
-    const updates = { is_active: !job.is_active };
-    const result = await update_job(job.id, updates);
-
-    if (result.success && onJobUpdate) {
-      onJobUpdate(updates);
-    } else if (result.code === "notifications_required") {
-      openNotificationsRequiredModal(handleToggleActive);
-    } else if (!result.success) {
-      toast.error(result.message || "Could not update this listing.");
+      if (result.success && onJobUpdate) {
+        onJobUpdate(updates);
+      } else if (result.code === "notifications_required") {
+        openNotificationsRequiredModal(handleToggleActive);
+      } else if (!result.success) {
+        toast.error(result.message || "Could not update this listing.");
+      }
+    } finally {
+      setTogglingActive(false);
     }
   };
 
@@ -218,6 +223,7 @@ export default function JobHeader({
                       <Toggle
                         state={job.is_active}
                         onClick={() => void handleToggleActive()}
+                        loading={togglingActive}
                       />
                     </div>
                     <span
@@ -408,6 +414,7 @@ export default function JobHeader({
                       <Toggle
                         state={job.is_active}
                         onClick={() => void handleToggleActive()}
+                        loading={togglingActive}
                       />
                     </div>
                     <span

--- a/components/features/hire/dashboard/JobHeader.tsx
+++ b/components/features/hire/dashboard/JobHeader.tsx
@@ -10,6 +10,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useListingsBusinessLogic } from "@/hooks/hire/listings/use-listings-business-logic";
 import { useAppContext } from "@/lib/ctx-app";
 import useModalRegistry from "@/components/modals/modal-registry";
+import { useNotificationsRequiredModal } from "@/hooks/use-notifications-required-modal";
 import {
   Tooltip,
   TooltipContent,
@@ -30,6 +31,7 @@ export default function JobHeader({
   const { ownedJobs, update_job, delete_job, unpause_job } = useOwnedJobs();
   const { saving } = useListingsBusinessLogic(ownedJobs);
   const [reEnabling, setReEnabling] = useState(false);
+  const openNotificationsRequiredModal = useNotificationsRequiredModal();
 
   const handleBack = () => {
     if (backHref) return router.replace(backHref);
@@ -44,6 +46,10 @@ export default function JobHeader({
 
     if (result.success && onJobUpdate) {
       onJobUpdate(updates);
+    } else if (result.code === "notifications_required") {
+      openNotificationsRequiredModal(handleToggleActive);
+    } else if (!result.success) {
+      toast.error(result.message || "Could not update this listing.");
     }
   };
 
@@ -59,6 +65,10 @@ export default function JobHeader({
           paused_at: null,
           waiting_count: 0,
         });
+      } else if (result.code === "notifications_required") {
+        openNotificationsRequiredModal(handleReEnable);
+      } else if (!result.success) {
+        toast.error(result.message || "Could not reactivate this listing.");
       }
     } finally {
       setReEnabling(false);

--- a/components/features/hire/dashboard/JobListingsBox.tsx
+++ b/components/features/hire/dashboard/JobListingsBox.tsx
@@ -11,6 +11,8 @@ import { FetchResponse } from "@/lib/api/use-fetch";
 import { ArrowRight, Check, Lock, Pause, Zap } from "lucide-react";
 import { useRouter } from "next/navigation";
 import useModalRegistry from "@/components/modals/modal-registry";
+import { toast } from "sonner";
+import { useNotificationsRequiredModal } from "@/hooks/use-notifications-required-modal";
 
 interface JobListingProps {
   job: Job;
@@ -27,6 +29,7 @@ export function JobListingsBox({
 }: JobListingProps) {
   const isSuperListing = Boolean(job.challenge);
   const [reEnabling, setReEnabling] = useState(false);
+  const openNotificationsRequiredModal = useNotificationsRequiredModal();
   const applicants = applications.filter(
     (application) =>
       application.job_id === job.id &&
@@ -39,7 +42,12 @@ export function JobListingsBox({
     if (!job.id || !onReactivate) return;
     setReEnabling(true);
     try {
-      await onReactivate(job.id);
+      const result = await onReactivate(job.id);
+      if (result.code === "notifications_required") {
+        openNotificationsRequiredModal(handleReEnable);
+      } else if (!result.success) {
+        toast.error(result.message || "Could not reactivate this listing.");
+      }
     } finally {
       setReEnabling(false);
     }

--- a/components/features/hire/paused-listings-banner.tsx
+++ b/components/features/hire/paused-listings-banner.tsx
@@ -2,18 +2,22 @@
 
 import { useState } from "react";
 import { AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
 import { Banner } from "@/components/ui/banner";
 import { Button } from "@/components/ui/button";
 import { Job } from "@/lib/db/db.types";
+import { FetchResponse } from "@/lib/api/use-fetch";
+import { useNotificationsRequiredModal } from "@/hooks/use-notifications-required-modal";
 
 export function PausedListingsBanner({
   jobs,
   onUnpauseAll,
 }: {
   jobs: Job[];
-  onUnpauseAll: () => Promise<unknown>;
+  onUnpauseAll: () => Promise<FetchResponse>;
 }) {
   const [reEnabling, setReEnabling] = useState(false);
+  const openNotificationsRequiredModal = useNotificationsRequiredModal();
   const pausedJobs = jobs.filter((job) => job.paused);
   const pausedCount = pausedJobs.length;
   const waitingTotal = pausedJobs.reduce(
@@ -26,7 +30,12 @@ export function PausedListingsBanner({
   const handleReEnableAll = async () => {
     setReEnabling(true);
     try {
-      await onUnpauseAll();
+      const result = await onUnpauseAll();
+      if (result.code === "notifications_required") {
+        openNotificationsRequiredModal(handleReEnableAll);
+      } else if (!result.success) {
+        toast.error(result.message || "Could not reactivate your listings.");
+      }
     } finally {
       setReEnabling(false);
     }

--- a/components/modals/modal-registry.tsx
+++ b/components/modals/modal-registry.tsx
@@ -29,6 +29,8 @@ import { Job, PublicUser } from "@/lib/db/db.types";
 import DeleteResumeModal from "./DeleteResumeModal";
 import { AddResumeModal } from "../features/student/profile/AddResumeModal";
 import { HeaderIcon } from "../ui/text";
+import { DigestOptoutModalContent } from "../features/hire/account/digest-optout-dialog";
+import type { EligibleListing } from "@/lib/api/services";
 
 const modalTitleWithIcon = (Icon: LucideIcon, title: string) => (
   <div className="flex min-w-0 items-center gap-3">
@@ -533,6 +535,39 @@ export const useModalRegistry = () => {
             },
           ),
         close: () => close("super-listing-closed"),
+      },
+
+      // Warns before turning off the applicant digest would leave every
+      // active listing unattended (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md).
+      digestOptout: {
+        open: ({
+          companyName,
+          listings,
+          onDone,
+        }: {
+          companyName: string;
+          listings: EligibleListing[];
+          onDone: () => void;
+        }) =>
+          open(
+            "digest-optout",
+            DefaultModalLayout,
+            <DigestOptoutModalContent
+              companyName={companyName}
+              listings={listings}
+              onDone={() => {
+                onDone();
+                close("digest-optout");
+              }}
+            />,
+            {
+              title: "Turn off applicant emails?",
+              closeOnBackdropClick: true,
+              closeOnEscapeKey: true,
+              showHeaderDivider: true,
+            },
+          ),
+        close: () => close("digest-optout"),
       },
 
       closeAll: () => close(),

--- a/components/modals/modal-registry.tsx
+++ b/components/modals/modal-registry.tsx
@@ -1,5 +1,5 @@
 import { useGlobalModal } from "../providers/modal-provider/ModalProvider";
-import { FileUp, LucideIcon, Trash2 } from "lucide-react";
+import { BellOff, FileUp, LucideIcon, Trash2 } from "lucide-react";
 import { FormSubmissionSuccessModal } from "./components/FormSubmissionSuccessModal";
 import { FollowUpFormModal } from "./components/ResendFormModal";
 import { CancelFormModal } from "./components/CancelFormModal";
@@ -568,6 +568,37 @@ export const useModalRegistry = () => {
             },
           ),
         close: () => close("digest-optout"),
+      },
+
+      // Blocks turning a listing back on (activating or reactivating) while
+      // zero teammates have applicant emails on — the inverse of
+      // digestOptout above (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md).
+      // Dismissible (X/backdrop/escape), unlike the generic `warning` entry.
+      notificationsRequired: {
+        open: ({ onTurnOn }: { onTurnOn: () => void }) =>
+          open(
+            "notifications-required",
+            DefaultModalLayout,
+            <WarningModal
+              icon={BellOff}
+              iconColor="text-amber-500"
+              title="Notifications are off"
+              message="No one on your team currently receives applicant emails. Turn on notifications before you can have active listings."
+              primaryAction={{
+                label: "Turn on notifications",
+                onClick: onTurnOn,
+              }}
+              close={() => close("notifications-required")}
+            />,
+            {
+              title: " ",
+              closeOnBackdropClick: true,
+              closeOnEscapeKey: true,
+              showCloseButton: true,
+              panelClassName: "sm:max-w-md",
+            },
+          ),
+        close: () => close("notifications-required"),
       },
 
       closeAll: () => close(),

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -3,19 +3,25 @@ import { cn } from "@/lib/utils";
 export const Toggle = ({
   state,
   onClick,
+  loading,
 }: {
   state: boolean | null | undefined;
   onClick: () => void;
+  loading?: boolean;
 }) => {
   return (
     <button
-      onClick={async (e) => {
+      type="button"
+      disabled={loading}
+      onClick={(e) => {
         e.stopPropagation();
+        if (loading) return;
         onClick();
       }}
       className={cn(
         "relative flex h-4 w-7 items-center rounded-full transition-colors focus:ring-transparent z-30",
-        state ? "bg-primary" : "bg-gray-300"
+        state ? "bg-primary" : "bg-gray-300",
+        loading ? "cursor-wait opacity-60" : "cursor-pointer"
       )}
     >
       <span

--- a/hooks/use-employer-api.tsx
+++ b/hooks/use-employer-api.tsx
@@ -351,9 +351,28 @@ export function useChangeMyPassword() {
 export function useUpdateMyNotifications() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (receivesDigest: boolean) =>
-      EmployerUserService.updateMyNotifications(receivesDigest),
+    mutationFn: ({
+      receivesDigest,
+      closeActiveListings,
+    }: {
+      receivesDigest: boolean;
+      closeActiveListings?: boolean;
+    }) =>
+      EmployerUserService.updateMyNotifications(
+        receivesDigest,
+        closeActiveListings,
+      ),
     onSuccess: () => invalidateAccountQueries(queryClient),
+  });
+}
+
+/** POST /jobs/deactivate-bulk — the digest opt-out dialog's "Close only these
+ * listings" action (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §6.4). Not
+ * tied to useOwnedJobs' local cache — callers refetch that hook explicitly
+ * once this resolves. */
+export function useDeactivateBulkJobs() {
+  return useMutation({
+    mutationFn: (jobIds: string[]) => JobService.deactivateBulk(jobIds),
   });
 }
 

--- a/hooks/use-notifications-required-modal.tsx
+++ b/hooks/use-notifications-required-modal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { useModalRegistry } from "@/components/modals/modal-registry";
+import { useUpdateMyNotifications } from "./use-employer-api";
+
+/**
+ * Opens the "no one receives applicant emails" blocker modal
+ * (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md's inverse guard, surfaced via
+ * jobs.controller.ts's `notifications_required` response code) with its CTA
+ * wired to turn the CURRENT user's own digest flag on — the lowest-friction
+ * fix, and always a plain success since turning the digest on never
+ * warns/cascades (D7/D8). Kept out of use-employer-api.tsx: modal-registry.tsx's
+ * digestOptout entry already imports from there, so importing it back would
+ * be a cycle.
+ *
+ * `onEnabled` is the original blocked action (the is_active toggle, a single
+ * unpause, or unpause-all) — it re-runs automatically once notifications are
+ * confirmed on, so one click on the modal's CTA is enough to end with at
+ * least one active listing, not just notifications turned on.
+ */
+export function useNotificationsRequiredModal() {
+  const modalRegistry = useModalRegistry();
+  const updateNotifications = useUpdateMyNotifications();
+
+  return useCallback(
+    (onEnabled?: () => void | Promise<void>) => {
+      modalRegistry.notificationsRequired.open({
+        onTurnOn: () => {
+          void updateNotifications
+            .mutateAsync({ receivesDigest: true })
+            .then(async (result) => {
+              if (!result.success) {
+                toast.error(
+                  result.message || "Could not turn on notifications.",
+                );
+                return;
+              }
+              toast.success("Notifications turned on.");
+              await onEnabled?.();
+            })
+            .catch((e: unknown) => {
+              toast.error(
+                e instanceof Error ? e.message : "Could not turn on notifications.",
+              );
+            });
+        },
+      });
+    },
+    [modalRegistry, updateNotifications],
+  );
+}

--- a/lib/api/api-client.ts
+++ b/lib/api/api-client.ts
@@ -120,9 +120,13 @@ class FetchClient {
       if (!response.ok && response.status !== 304) {
         const errorData = (await response.json().catch(() => ({}))) as {
           message?: string;
+          [key: string]: unknown;
         };
         console.warn(`${url}: ${errorData.message || response.status}`);
-        return { error: errorData.message } as T;
+        // Spread first so `.error` (the field every existing caller reads)
+        // always wins, while extra structured fields an endpoint attaches to
+        // its error body (e.g. eligible_listings on a 409) still survive.
+        return { ...errorData, error: errorData.message } as T;
         // throw new Error(errorData.message || "Something went wrong.");
       }
 

--- a/lib/api/services.ts
+++ b/lib/api/services.ts
@@ -113,6 +113,22 @@ interface EmployerSelfResponse extends FetchResponse {
   user: EmployerSelf;
 }
 
+// A listing named in the 409 body (or, on success, actually closed) by the
+// last-subscriber cascade (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §6.3).
+export interface EligibleListing {
+  id: string;
+  title: string;
+}
+
+interface UpdateNotificationsResponse extends EmployerSelfResponse {
+  // Present on a 409: this write would leave zero subscribed recipients with
+  // active listings still open. Absent on success.
+  eligible_listings?: EligibleListing[];
+  // Present on success when close_active_listings actually triggered a
+  // cascade; otherwise [].
+  closed_listing_ids?: string[];
+}
+
 interface EmployerTeamResponse extends FetchResponse {
   users: EmployerTeamMember[];
 }
@@ -162,10 +178,13 @@ export const EmployerUserService = {
     );
   },
 
-  async updateMyNotifications(receives_applicant_digest: boolean) {
-    return APIClient.patch<EmployerSelfResponse>(
+  async updateMyNotifications(
+    receives_applicant_digest: boolean,
+    close_active_listings?: boolean,
+  ) {
+    return APIClient.patch<UpdateNotificationsResponse>(
       APIRouteBuilder("employer-users").r("me", "notifications").build(),
-      { receives_applicant_digest },
+      { receives_applicant_digest, close_active_listings },
     );
   },
 
@@ -645,6 +664,10 @@ interface WaitlistedJobsResponse extends FetchResponse {
   waitlisted?: JobWaitlist[];
 }
 
+interface DeactivateBulkResponse extends FetchResponse {
+  job_ids: string[];
+}
+
 export const JobService = {
   async getAllJobs() {
     return APIClient.get<JobsResponse>(APIRouteBuilder("jobs").build());
@@ -734,6 +757,13 @@ export const JobService = {
   async unpauseAllJobs() {
     return APIClient.post<FetchResponse>(
       APIRouteBuilder("jobs").r("unpause-all").build(),
+    );
+  },
+
+  async deactivateBulk(jobIds: string[]) {
+    return APIClient.post<DeactivateBulkResponse>(
+      APIRouteBuilder("jobs").r("deactivate-bulk").build(),
+      { job_ids: jobIds },
     );
   },
 

--- a/lib/api/use-fetch.ts
+++ b/lib/api/use-fetch.ts
@@ -11,4 +11,8 @@
 export interface FetchResponse {
   success?: boolean;
   message?: string;
+  // Present on some failure responses so the client can distinguish a specific,
+  // known failure reason from a generic one without string-matching `message`
+  // (e.g. "notifications_required" — see jobs.controller.ts).
+  code?: string;
 }

--- a/lib/db/db.types.ts
+++ b/lib/db/db.types.ts
@@ -78,6 +78,11 @@ export interface EmployerSelf
   role: EmployerUserRole;
   is_owner: boolean;
   receives_applicant_digest: boolean;
+  // Live teammates, excluding self, with the digest flag on
+  // (Docs/plans/DIGEST_UNSUBSCRIBE_MODAL_PLAN.md §6.2) — lets the
+  // Notifications tab know whether turning its own flag off would be the
+  // last one, without the ADMIN-only listTeam endpoint.
+  other_subscribed_recipients: number;
 }
 
 export interface EmployerTeamMember


### PR DESCRIPTION
**Digest opt-out (turning notifications off)**
- Reworded the digest email's unsubscribe link from "Manage your notifications" to "Turn off your notifications"
- New warning modal (shared modal system) fires when the last subscribed teammate tries to turn off their digest while the employer still has active listings — offers "Close only these listings" (bulk-deactivates just those, hibernating listings excluded from the count) vs "Turn off all emails anyway"
- The eligible-listings set is re-derived server-side at confirm time rather than trusted from the client, so a stale client can't act on an outdated list

**Notifications-required guard (turning notifications on / reactivating)**
- Blocks activating a listing, unpausing a single listing, or unpausing all listings when the employer currently has zero teammates with digest notifications enabled
- Replaces the old toast with a dedicated "Notifications are off" modal ("Turn on notifications" CTA, dismissible via X)
- Confirming the CTA turns on the current user's own digest flag, then automatically retries whichever action was originally blocked — so one click reliably ends with at least one active listing, not just notifications turned on

**Other Changes**
- The job-activity toggle and the notifications switch now show a loading cursor + dimmed state while their request is in flight, instead of appearing to hang with no feedback
- Fixed the digest opt-out modal's backdrop coverage/z-index, spacing, and "select all" control styling